### PR TITLE
OpenFiscaからエラーレスポンスが返った場合のエラー画面を追加

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -6,6 +6,7 @@ import { Result } from "./components/result/result";
 import { GenericError } from "./components/errors/GenericError";
 import { NotFoundError } from "./components/errors/NotFoundError";
 import { CurrentDateContext } from "./contexts/CurrentDateContext";
+import { FormResponseError } from "./components/errors/FormResponseError";
 
 function App() {
   const currentDate = `${new Date().getFullYear()}-${(new Date().getMonth() + 1)
@@ -43,6 +44,10 @@ function App() {
               {
                 path: "/result",
                 element: <Result />,
+              },
+              {
+                path: "/response-error",
+                element: <FormResponseError />,
               },
               {
                 path: "/*",

--- a/dashboard/src/components/errors/FormResponseError.tsx
+++ b/dashboard/src/components/errors/FormResponseError.tsx
@@ -1,0 +1,37 @@
+import { Box, Button, Center } from "@chakra-ui/react"
+import { Link as RouterLink, useLocation } from "react-router-dom";
+import configData from "../../config/app_config.json";
+
+export const FormResponseError = () => {
+  const location = useLocation();
+  const { isSimpleCalculation } = location.state as {
+    isSimpleCalculation: boolean;
+  };
+
+  return (
+    <Box bg="white" borderRadius="xl" p={4} mt={4} mb={4} ml={4} mr={4}>
+      <Center mb={4} fontSize={configData.style.subTitleFontSize}>
+          <h1>予期せぬエラーが発生しました</h1>
+      </Center>
+      <Center mb={4}>
+          <div>お手数ですがもう一度情報を入力してください。</div>
+      </Center>
+
+      <Center pr={4} pl={4} pb={4} mt={8} style={{ textAlign: "center" }}>
+          <Button
+            fontSize={configData.style.subTitleFontSize}
+            borderRadius="xl"
+            height="2em"
+            width="100%"
+            bg="cyan.600"
+            color="white"
+            _hover={{ bg: "cyan.700" }}
+            as={RouterLink}
+            to={isSimpleCalculation ? "/calculate-simple" : "/calculate"}
+          >
+            戻る
+          </Button>
+        </Center>
+    </Box>
+  )
+}

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -1,4 +1,4 @@
-import { Link as RouterLink, useLocation } from "react-router-dom";
+import { Navigate, Link as RouterLink, useLocation, useNavigate } from "react-router-dom";
 
 import {
   Box,
@@ -38,6 +38,7 @@ export const Result = () => {
   };
 
   const [isLabelOpen, setIsLabelOpen] = useState(false);
+  const navigate = useNavigate();
 
   const currentDate = useContext(CurrentDateContext);
   const [result, calculate] = useCalculate();
@@ -45,7 +46,14 @@ export const Result = () => {
   let calcOnce = true;
   useEffect(() => {
     if (calcOnce) {
-      calculate(household);
+      calculate(household).catch((e: any) => {
+        // 想定外のエラーレスポンスを受け取り結果が取得できなかった場合、エラー画面へ遷移
+        navigate("/response-error", {
+          state: {
+            isSimpleCalculation: isSimpleCalculation,
+          },
+        });
+      });
       calcOnce = false;
     }
   }, []);

--- a/dashboard/src/hooks/calculate.ts
+++ b/dashboard/src/hooks/calculate.ts
@@ -24,6 +24,15 @@ export const useCalculate = () => {
       },
       body: JSON.stringify(household),
     });
+
+    // NOTE: エラーレスポンスを受け取った場合resultの生成ができないため、例外を出し終了
+    if (!newResultRes.ok) {
+      const errBody = await newResultRes.text();
+      const errMsg = `unexpected error response: status: ${newResultRes.status}, body: ${errBody}`
+      console.log(errMsg); // debug log
+      throw new Error(errMsg);
+    }
+
     const newResultJson = await newResultRes.json();
     console.log(newResultJson); // debug log
     delete newResultJson.世帯.世帯1.自分一覧;


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は フロントエンドでOpenFiscaからエラーレスポンスが返った場合処理 を改善する
  - そのために エラー画面 を追加した
  - そのために OpenFiscaレスポンスのパース処理 を変更した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
  - 誕生日を未来日に設定しリクエスト（未対応の処理）した際に以下のエラー画面に遷移することを確認

![image](https://github.com/project-inclusive/OpenFisca-Japan/assets/36665200/da5a8f97-04a9-4cbf-840d-72f93c7d9b4d)


対応issue #97
