### PR TITLE
OpenFiscaで使用すべきでない関数を検知するlinter追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ check-style:
 	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
 	flake8 `git ls-files | grep "\.py$$"`
 	pylint `git ls-files | grep "\.py$$"`
+	@# check variables meet openfisca coding style
+	@# `grep` cannot be used here because it ignores Japanese file names.
+	ruff check
 
 lint: clean check-syntax-errors check-style
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,6 +72,7 @@ requests==2.31.0
 requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==13.4.2
+ruff==0.1.9
 SecretStorage==3.3.3
 six==1.16.0
 snowballstemmer==2.2.0

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,11 @@
+# 使うべきでない関数を使用しているかどうかのみ検証
+select = ["TID"]
+
+[lint.flake8-tidy-imports.banned-api]
+"enum".msg = "Enumを表現したい場合は openfisca_core.indexed_enums.Enum を使用してください。"
+"numpy.max".msg = "複数世帯の場合に正しく計算できないため、代わりに 対象世帯.max を使用してください。"
+"numpy.min".msg = "複数世帯の場合に正しく計算できないため、代わりに 対象世帯.min を使用してください。"
+"numpy.all".msg = "複数世帯の場合に正しく計算できないため、代わりに 対象世帯.all を使用してください。"
+"numpy.any".msg = "複数世帯の場合に正しく計算できないため、代わりに 対象世帯.any を使用してください。"
+"numpy.sum".msg = "複数世帯の場合に正しく計算できないため、代わりに 対象世帯.sum を使用してください。"
+"numpy.argsort".msg = "複数世帯の場合に正しく計算できないため、世帯員を年齢順にしたい場合は 対象世帯.get_rank を使用してください。"

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(
             "pylint >= 2.6.0, < 3.0.0",
             "pycodestyle >= 2.6.0, < 3.0.0",
             "python-dateutil > 2.8.1",
-            "PyYAML == 6.0"
+            "PyYAML == 6.0",
+            "ruff == 0.1.9"
             ],
         },
     packages = find_packages(),


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は 複数世帯計算に使用できない関数を使用した場合の警告 を追加する
  - そのために linter (Ruff) を追加した

## 動作確認

- [x] 追加したコマンドの動作を目視確認した

```bash
$ ruff check
openfisca_japan/variables/住民税.py:139:14: TID251 `numpy.any` is banned: 複数世帯の場合に正しく計算できないため、代わりに 対象世帯.any を使用してください。
openfisca_japan/variables/住民税.py:170:18: TID251 `numpy.max` is banned: 複数世帯の場合に正しく計算できないため、代わりに 対象世帯.max を使用してください。
openfisca_japan/variables/住民税.py:171:22: TID251 `numpy.min` is banned: 複数世帯の場合に正しく計算できないため、代わりに 対象世帯.min を使用してください。
openfisca_japan/variables/住民税.py:224:18: TID251 `numpy.max` is banned: 複数世帯の場合に正しく計算できないため、代わりに 対象世帯.max を使用してください。
openfisca_japan/variables/住民税.py:225:22: TID251 `numpy.min` is banned: 複数世帯の場合に正しく計算できないため、代わりに 対象世帯.min を使用してください。
...
```

関連issue #143 
