### PR TITLE
能登半島地震被災者支援制度フォームを追加

### DIFF
--- a/dashboard/cypress/e2e/DetailedCalculation.cy.js
+++ b/dashboard/cypress/e2e/DetailedCalculation.cy.js
@@ -6,10 +6,10 @@ describe('Renders main page and ', () => {
 
   it('navigates to detailed calculate page', () => {
     cy.contains('支援みつもりヤドカリくん');
-    cy.contains('くわしく計算');
-    cy.get('.css-1icvf0w').contains('くわしく計算').click();
+    cy.contains('くわしく見積もり');
+    cy.get('.css-1icvf0w').contains('くわしく見積もり').click();
     cy.url().should('include', '/calculate');
     cy.contains('あなたについて');
-    cy.contains('くわしく計算');
+    cy.contains('くわしく見積もり');
   });
 });

--- a/dashboard/cypress/e2e/Homepage.cy.js
+++ b/dashboard/cypress/e2e/Homepage.cy.js
@@ -8,11 +8,11 @@ describe('Loads homepage', () => {
     cy.contains('支援みつもりヤドカリくん');
   });
 
-  it('Renders かんたん計算 button', () => {
-    cy.contains('かんたん計算');
+  it('Renders かんたん見積もり button', () => {
+    cy.contains('かんたん見積もり');
   });
 
-  it('Renders くわしく計算 button', () => {
-    cy.contains('くわしく計算');
+  it('Renders くわしく見積もり button', () => {
+    cy.contains('くわしく見積もり');
   });
 });

--- a/dashboard/cypress/e2e/SimpleCalculation.cy.js
+++ b/dashboard/cypress/e2e/SimpleCalculation.cy.js
@@ -6,8 +6,8 @@ describe('Renders main page and ', () => {
 
   it('navigates to simple calculate page, fill in mandatory fields', () => {
     cy.contains('支援みつもりヤドカリくん');
-    cy.contains('かんたん計算');
-    cy.get('.css-s00sbd').contains('かんたん計算').click();
+    cy.contains('かんたん見積もり');
+    cy.get('.css-s00sbd').contains('かんたん見積もり').click();
     cy.url().should('include', '/calculate-simple');
     cy.contains('あなたについて');
 

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -43,6 +43,10 @@ function App() {
               element: <CaluculationForm />,
             },
             {
+              path: '/calculate-disaster',
+              element: <CaluculationForm />,
+            },
+            {
               path: '/result',
               element: <Result />,
             },

--- a/dashboard/src/components/Description.tsx
+++ b/dashboard/src/components/Description.tsx
@@ -1,6 +1,19 @@
 import { useState, useEffect } from 'react';
 import { Link as RouterLink } from 'react-router-dom';
-import { Box, Center, Button, VStack, Image } from '@chakra-ui/react';
+import {
+  Box,
+  Center,
+  Button,
+  VStack,
+  Image,
+  Accordion,
+  AccordionItem,
+  AccordionIcon,
+  AccordionButton,
+  AccordionPanel,
+  UnorderedList,
+  ListItem,
+} from '@chakra-ui/react';
 import { Icon } from '@chakra-ui/react';
 import { CheckCircleIcon } from '@chakra-ui/icons';
 import { FaGithub } from 'react-icons/fa';
@@ -92,6 +105,39 @@ function Description() {
           {configData.description.description[2]}
         </Box>
 
+        {/* 見積もり対象制度一覧 */}
+        <Accordion mb={4} allowMultiple>
+          <AccordionItem>
+            <h2>
+              <AccordionButton>
+                <AccordionIcon />
+                <Box flex="1" textAlign="left" fontWeight="semibold">
+                  見積もり対象制度一覧
+                </Box>
+              </AccordionButton>
+            </h2>
+            <AccordionPanel pb={4}>
+              <UnorderedList ml={8} mt={1}>
+                <ul>
+                  {Object.entries(configData.result.給付制度.制度一覧).map(
+                    (entry: any, index: number) => (
+                      <ListItem>
+                        <Box color="blue">
+                          <a href={entry[1].reference}>
+                            {entry[0]}
+                            {entry[1].local && `(${entry[1].local})`}
+                          </a>
+                        </Box>
+                      </ListItem>
+                    )
+                  )}
+                </ul>
+              </UnorderedList>
+            </AccordionPanel>
+          </AccordionItem>
+        </Accordion>
+
+        {/* icon */}
         <Center>
           <a href={configData.URL.contact}>
             <VStack mr={4}>

--- a/dashboard/src/components/Description.tsx
+++ b/dashboard/src/components/Description.tsx
@@ -119,6 +119,7 @@ function Description() {
             <AccordionPanel pb={4}>
               <UnorderedList ml={8} mt={1}>
                 <ul>
+                  {/* benefit 給付制度 */}
                   {Object.entries(configData.result.給付制度.制度一覧).map(
                     (entry: any, index: number) => (
                       <ListItem key={index}>
@@ -131,6 +132,50 @@ function Description() {
                       </ListItem>
                     )
                   )}
+
+                  {/* loan 貸付制度 */}
+                  {Object.entries(
+                    configData.result.貸付制度.その他.制度一覧
+                  ).map((entry: any, index: number) => (
+                    <ListItem key={index}>
+                      <Box color="blue">
+                        <a href={entry[1].reference}>
+                          {entry[0]}
+                          {entry[1].local && `(${entry[1].local})`}
+                        </a>
+                      </Box>
+                    </ListItem>
+                  ))}
+
+                  <ListItem>
+                    <Box color="blue">
+                      <a
+                        href={
+                          configData.result.貸付制度.生活福祉資金貸付制度
+                            .reference
+                        }
+                      >
+                        生活福祉資金貸付制度
+                      </a>
+                    </Box>
+                    <UnorderedList ml={8} mt={1}>
+                      <ul>
+                        {Object.entries(
+                          configData.result.貸付制度.生活福祉資金貸付制度
+                            .制度一覧
+                        ).map((entry: any, index: number) => (
+                          <ListItem key={index}>
+                            <Box color="blue">
+                              <a href={entry[1].reference}>
+                                {entry[0]}
+                                {entry[1].local && `(${entry[1].local})`}
+                              </a>
+                            </Box>
+                          </ListItem>
+                        ))}
+                      </ul>
+                    </UnorderedList>
+                  </ListItem>
                 </ul>
               </UnorderedList>
             </AccordionPanel>

--- a/dashboard/src/components/Description.tsx
+++ b/dashboard/src/components/Description.tsx
@@ -121,7 +121,7 @@ function Description() {
                 <ul>
                   {Object.entries(configData.result.給付制度.制度一覧).map(
                     (entry: any, index: number) => (
-                      <ListItem>
+                      <ListItem key={index}>
                         <Box color="blue">
                           <a href={entry[1].reference}>
                             {entry[0]}

--- a/dashboard/src/components/Description.tsx
+++ b/dashboard/src/components/Description.tsx
@@ -111,6 +111,24 @@ function Description() {
       <Center pr={4} pl={4} pb={4} style={{ textAlign: 'center' }}>
         <Button
           as={RouterLink}
+          to="/calculate-disaster"
+          fontSize={configData.style.subTitleFontSize}
+          borderRadius="xl"
+          height="4em"
+          width="100%"
+          bg="orange.400"
+          color="white"
+          _hover={{ bg: 'orange.500' }}
+        >
+          能登半島地震
+          <br />
+          被災者支援制度見積もり
+        </Button>
+      </Center>
+
+      <Center pr={4} pl={4} pb={4} style={{ textAlign: 'center' }}>
+        <Button
+          as={RouterLink}
           to="/calculate"
           style={{ marginRight: '8%' }}
           fontSize={configData.style.subTitleFontSize}
@@ -123,7 +141,7 @@ function Description() {
         >
           くわしく
           <br />
-          計算
+          見積もり
         </Button>
         <Button
           as={RouterLink}
@@ -138,7 +156,7 @@ function Description() {
         >
           かんたん
           <br />
-          計算
+          見積もり
         </Button>
       </Center>
     </>

--- a/dashboard/src/components/Description.tsx
+++ b/dashboard/src/components/Description.tsx
@@ -17,7 +17,9 @@ import {
 import { Icon } from '@chakra-ui/react';
 import { CheckCircleIcon } from '@chakra-ui/icons';
 import { FaGithub } from 'react-icons/fa';
+import { useResetRecoilState } from 'recoil';
 
+import { householdAtom } from '../state';
 import configData from '../config/app_config.json';
 import bokyuIcon from '../assets/bokyu_lab_icon_cyan.png';
 import yadokariKunIcon from '../assets/yadokari-kun.png';
@@ -27,6 +29,7 @@ const defaultInnerWidth = window.innerWidth;
 function Description() {
   const [screenWidth, setScreenWidth] = useState(defaultInnerWidth);
   const [isMobile, setIsMobile] = useState(defaultInnerWidth <= 800);
+  const resetHousehold = useResetRecoilState(householdAtom);
 
   useEffect(() => {
     function handleResize() {

--- a/dashboard/src/components/errors/FormResponseError.tsx
+++ b/dashboard/src/components/errors/FormResponseError.tsx
@@ -4,8 +4,9 @@ import configData from '../../config/app_config.json';
 
 export const FormResponseError = () => {
   const location = useLocation();
-  const { isSimpleCalculation } = location.state as {
+  const { isSimpleCalculation, isDisasterCalculation } = location.state as {
     isSimpleCalculation: boolean;
+    isDisasterCalculation: boolean;
   };
 
   return (
@@ -27,7 +28,13 @@ export const FormResponseError = () => {
           color="white"
           _hover={{ bg: 'cyan.700' }}
           as={RouterLink}
-          to={isSimpleCalculation ? '/calculate-simple' : '/calculate'}
+          to={
+            isSimpleCalculation
+              ? '/calculate-simple'
+              : isDisasterCalculation
+              ? '/calculate-disaster'
+              : '/calculate'
+          }
         >
           戻る
         </Button>

--- a/dashboard/src/components/forms/attributes/PrefectureMunicipality.tsx
+++ b/dashboard/src/components/forms/attributes/PrefectureMunicipality.tsx
@@ -70,7 +70,6 @@ export const PrefectureMunicipality = ({
           delete newHousehold.世帯一覧.世帯1.受験生チャレンジ支援貸付;
         }
       }
-      console.log(newHousehold);
       setHousehold({ ...newHousehold });
     },
     []

--- a/dashboard/src/components/forms/attributes/SpouseExists.tsx
+++ b/dashboard/src/components/forms/attributes/SpouseExists.tsx
@@ -36,8 +36,6 @@ export const SpouseExists = () => {
 
   // stored states set checkbox when page transition
   useEffect(() => {
-    console.log(navigationType);
-    console.log(household);
     setIsChecked(household.世帯一覧.世帯1.親一覧.length === 2);
   }, [navigationType]);
 

--- a/dashboard/src/components/forms/children.tsx
+++ b/dashboard/src/components/forms/children.tsx
@@ -14,7 +14,7 @@ import { householdAtom } from '../../state';
 
 export const FormChildren = () => {
   const location = useLocation();
-  const isSimpleCalculation = location.pathname === '/calculate-simple';
+  const isDetailedCalculation = location.pathname === '/calculate';
 
   const household = useRecoilValue(householdAtom);
 
@@ -34,18 +34,20 @@ export const FormChildren = () => {
                   {configData.calculationForm.childrenDescription}
                 </Center>
 
-                {isSimpleCalculation ? (
-                  <AgeInput personName={childName} mustInput />
-                ) : (
+                {isDetailedCalculation ? (
                   <Birthday personName={childName} mustInput={true} />
+                ) : (
+                  <AgeInput personName={childName} mustInput />
                 )}
-                {!isSimpleCalculation && <HighSchool personName={childName} />}
-                {!isSimpleCalculation && <Working personName={childName} />}
-                {!isSimpleCalculation && <Disability personName={childName} />}
-                {!isSimpleCalculation && (
+                {isDetailedCalculation && <HighSchool personName={childName} />}
+                {isDetailedCalculation && <Working personName={childName} />}
+                {isDetailedCalculation && <Disability personName={childName} />}
+                {isDetailedCalculation && (
                   <Recuperation personName={childName} />
                 )}
-                {!isSimpleCalculation && <NursingHome personName={childName} />}
+                {isDetailedCalculation && (
+                  <NursingHome personName={childName} />
+                )}
               </Box>
             </div>
           )

--- a/dashboard/src/components/forms/formContent.tsx
+++ b/dashboard/src/components/forms/formContent.tsx
@@ -16,6 +16,7 @@ import { householdAtom } from '../../state';
 export const FormContent = () => {
   const location = useLocation();
   const isSimpleCalculation = location.pathname === '/calculate-simple';
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
 
   const [ShowAlertMessage, setShowAlertMessage] = useState(false);
   const validated = useValidate();
@@ -30,9 +31,17 @@ export const FormContent = () => {
           text={
             isSimpleCalculation
               ? configData.calculationForm.simpleCalculation
+              : isDisasterCalculation
+              ? configData.calculationForm.disasterCalculation
               : configData.calculationForm.detailedCalculation
           }
-          colour={isSimpleCalculation ? 'teal' : 'blue'}
+          colour={
+            isSimpleCalculation
+              ? 'teal'
+              : isDisasterCalculation
+              ? 'orange'
+              : 'blue'
+          }
         />
 
         <Center
@@ -53,7 +62,7 @@ export const FormContent = () => {
 
         <Center pr={4} pl={4} pb={4}>
           <Button
-            loadingText="計算する"
+            loadingText="見積もる"
             fontSize={configData.style.subTitleFontSize}
             borderRadius="xl"
             height="2em"
@@ -72,11 +81,12 @@ export const FormContent = () => {
                 state: {
                   household: household,
                   isSimpleCalculation: isSimpleCalculation,
+                  isDisasterCalculation: isDisasterCalculation,
                 },
               });
             }}
           >
-            計算する
+            見積もる
           </Button>
         </Center>
       </div>

--- a/dashboard/src/components/forms/parents.tsx
+++ b/dashboard/src/components/forms/parents.tsx
@@ -15,12 +15,12 @@ import { householdAtom } from '../../state';
 
 export const FormParents = () => {
   const location = useLocation();
-  const isSimpleCalculation = location.pathname === '/calculate-simple';
+  const isDetailedCalculation = location.pathname === '/calculate';
   const [household, setHousehold] = useRecoilState(householdAtom);
 
   return (
     <>
-      {!isSimpleCalculation &&
+      {isDetailedCalculation &&
         household.世帯一覧.世帯1.祖父母一覧 &&
         household.世帯一覧.世帯1.祖父母一覧.map(
           (parentName: string, index: number) => (

--- a/dashboard/src/components/forms/spouse.tsx
+++ b/dashboard/src/components/forms/spouse.tsx
@@ -16,7 +16,7 @@ import { householdAtom } from '../../state';
 
 export const FormSpouse = () => {
   const location = useLocation();
-  const isSimpleCalculation = location.pathname === '/calculate-simple';
+  const isDetailedCalculation = location.pathname === '/calculate';
   const [household, setHousehold] = useRecoilState(householdAtom);
 
   const spouseName = '配偶者';
@@ -34,17 +34,17 @@ export const FormSpouse = () => {
               {configData.calculationForm.spouseDescription}
             </Center>
 
-            {!isSimpleCalculation && (
+            {isDetailedCalculation && (
               <Birthday personName={spouseName} mustInput={true} />
             )}
             <Income personName={spouseName} mustInput={true} />
-            {!isSimpleCalculation && <Deposit personName={spouseName} />}
-            {!isSimpleCalculation && <Student personName={spouseName} />}
-            {!isSimpleCalculation && <Working personName={spouseName} />}
-            {!isSimpleCalculation && <Disability personName={spouseName} />}
-            {!isSimpleCalculation && <Recuperation personName={spouseName} />}
-            {!isSimpleCalculation && <NursingHome personName={spouseName} />}
-            {!isSimpleCalculation && (
+            {isDetailedCalculation && <Deposit personName={spouseName} />}
+            {isDetailedCalculation && <Student personName={spouseName} />}
+            {isDetailedCalculation && <Working personName={spouseName} />}
+            {isDetailedCalculation && <Disability personName={spouseName} />}
+            {isDetailedCalculation && <Recuperation personName={spouseName} />}
+            {isDetailedCalculation && <NursingHome personName={spouseName} />}
+            {isDetailedCalculation && (
               <SpouseExistsButSingleParent personName={spouseName} />
             )}
           </Box>

--- a/dashboard/src/components/forms/you.tsx
+++ b/dashboard/src/components/forms/you.tsx
@@ -19,7 +19,7 @@ import { Deposit } from './attributes/Deposit';
 
 export const FormYou = () => {
   const location = useLocation();
-  const isSimpleCalculation = location.pathname === '/calculate-simple';
+  const isDetailedCalculation = location.pathname === '/calculate';
 
   const yourName = 'あなた';
   return (
@@ -33,21 +33,21 @@ export const FormYou = () => {
           {configData.calculationForm.youDescription}
         </Center>
         <PrefectureMunicipality mustInput={true} />
-        {!isSimpleCalculation && (
+        {isDetailedCalculation && (
           <Birthday personName={yourName} mustInput={true} />
         )}
         <Income personName={yourName} mustInput={true} />
-        {!isSimpleCalculation && <Deposit personName={yourName} />}
-        {!isSimpleCalculation && <Student personName={yourName} />}
-        {!isSimpleCalculation && <Working personName={yourName} />}
-        {!isSimpleCalculation && <Disability personName={yourName} />}
-        {!isSimpleCalculation && <Recuperation personName={yourName} />}
-        {!isSimpleCalculation && <NursingHome personName={yourName} />}
+        {isDetailedCalculation && <Deposit personName={yourName} />}
+        {isDetailedCalculation && <Student personName={yourName} />}
+        {isDetailedCalculation && <Working personName={yourName} />}
+        {isDetailedCalculation && <Disability personName={yourName} />}
+        {isDetailedCalculation && <Recuperation personName={yourName} />}
+        {isDetailedCalculation && <NursingHome personName={yourName} />}
         <SpouseExists />
         <ChildrenNum />
-        {!isSimpleCalculation && <ParentsNum />}
-        {!isSimpleCalculation && <Pregnant personName={yourName} />}
-        {!isSimpleCalculation && <RentingHouse />}
+        {isDetailedCalculation && <ParentsNum />}
+        {isDetailedCalculation && <Pregnant personName={yourName} />}
+        {isDetailedCalculation && <RentingHouse />}
       </Box>
     </>
   );

--- a/dashboard/src/components/result/helpDesk.tsx
+++ b/dashboard/src/components/result/helpDesk.tsx
@@ -1,0 +1,136 @@
+import { Box, Link, Text } from '@chakra-ui/react';
+import { ExternalLinkIcon } from '@chakra-ui/icons';
+
+import { data as SocialWelfareData } from '../../config/社会福祉協議会';
+import { currentDateAtom, householdAtom } from '../../state';
+import { useRecoilValue } from 'recoil';
+
+export const HelpDesk = () => {
+  const currentDate = useRecoilValue(currentDateAtom);
+  const household = useRecoilValue(householdAtom);
+
+  const prefecture = household.世帯一覧.世帯1.居住都道府県[currentDate];
+
+  const city = household.世帯一覧.世帯1.居住市区町村[currentDate];
+
+  const getSocialWelfareCouncilData = () => {
+    if (
+      prefecture === '東京都' &&
+      SocialWelfareData.東京都.hasOwnProperty(city)
+    ) {
+      const {
+        施設名,
+        郵便番号,
+        所在地,
+        経度,
+        緯度,
+        座標系,
+        電話番号,
+        WebサイトURL,
+      } = SocialWelfareData.東京都[city];
+
+      return {
+        施設名,
+        郵便番号,
+        所在地,
+        経度,
+        緯度,
+        座標系,
+        電話番号,
+        WebサイトURL,
+        googleMapsURL: encodeURI(
+          `https://www.google.com/maps/search/${施設名}+${所在地}`
+        ),
+      };
+    }
+
+    return {
+      施設名: null,
+      郵便番号: null,
+      所在地: null,
+      経度: null,
+      緯度: null,
+      座標系: null,
+      電話番号: null,
+      WebサイトURL: '',
+      googleMapsURL: '',
+    };
+  };
+
+  const aboutLink = {
+    link: 'https://www.zcwvc.net/about/list.html',
+    title: '全国の社会福祉協議会一覧',
+  };
+
+  return (
+    <Box
+      bg="white"
+      borderRadius="xl"
+      pt={1}
+      pb={1}
+      pr={2}
+      pl={2}
+      m={2}
+      border="1px solid black"
+    >
+      {prefecture === '東京都' ? (
+        <Box>
+          {getSocialWelfareCouncilData().WebサイトURL ? (
+            <Link
+              href={getSocialWelfareCouncilData().WebサイトURL}
+              color="blue.500"
+              fontWeight={'semibold'}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {getSocialWelfareCouncilData().施設名}
+            </Link>
+          ) : (
+            <Text fontWeight={'semibold'}>
+              {getSocialWelfareCouncilData().施設名}
+            </Text>
+          )}
+          <Text>〒{getSocialWelfareCouncilData().郵便番号}</Text>
+          <Link
+            href={getSocialWelfareCouncilData().googleMapsURL}
+            color="blue.500"
+            fontWeight={'semibold'}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            地図を開く
+            <ExternalLinkIcon ml={1} />
+          </Link>
+          <br />
+          <Text>
+            TEL:
+            <Link
+              href={`tel:${getSocialWelfareCouncilData().電話番号}`}
+              color="blue.500"
+              fontWeight={'semibold'}
+            >
+              {getSocialWelfareCouncilData().電話番号}
+            </Link>
+          </Text>
+        </Box>
+      ) : (
+        <Box>
+          <Text fontWeight={'semibold'}>社会福祉協議会の調べ方</Text>
+          <Text>
+            下記のページからお住まいの社会福祉協議会を選択してください
+          </Text>
+          <Link
+            href={aboutLink.link}
+            color="blue.500"
+            fontWeight={'semibold'}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {aboutLink.title}
+            <ExternalLinkIcon ml={1} />
+          </Link>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/dashboard/src/components/result/loan.tsx
+++ b/dashboard/src/components/result/loan.tsx
@@ -85,24 +85,29 @@ export const Loan = ({ result }: { result: any }) => {
     const loanResult: Obj = {};
 
     if (result) {
-      for (const [loanName, loanInfo] of Object.entries(
-        configData.result.貸付制度.制度一覧
+      for (const [categoryName, categoryInfo] of Object.entries(
+        configData.result.貸付制度
       )) {
-        if (loanName in result.世帯一覧.世帯1) {
-          if (result.世帯一覧.世帯1[loanName][currentDate] > 0) {
-            loanResult[loanName] = {
-              name: loanName,
-              unit: loanInfo.unit,
-              caption: loanInfo.caption,
-              reference: loanInfo.reference,
-              displayedMoney: Number(
-                result.世帯一覧.世帯1[loanName][currentDate]
-              ),
-            };
+        loanResult[categoryName] = {};
+        for (const [loanName, loanInfo] of Object.entries(
+          categoryInfo.制度一覧
+        )) {
+          if (loanName in result.世帯一覧.世帯1) {
+            if (result.世帯一覧.世帯1[loanName][currentDate] > 0) {
+              loanResult[categoryName][loanName] = {
+                name: loanName,
+                unit: loanInfo.unit,
+                caption: loanInfo.caption,
+                reference: loanInfo.reference,
+                displayedMoney: Number(
+                  result.世帯一覧.世帯1[loanName][currentDate]
+                ),
+              };
+            }
           }
         }
       }
-
+      console.log(loanResult);
       setDisplayedResult(loanResult);
       console.log(`display ${JSON.stringify(displayedResult)}`);
     }
@@ -119,137 +124,162 @@ export const Loan = ({ result }: { result: any }) => {
           >
             {configData.result.loanDescription}
           </Center>
-
-          <Box fontWeight="medium" mb={2}>
-            {/* TODO: 他の貸付制度を追加したらconfigDataから読み込むようにする */}
-            生活福祉資金貸付制度
-          </Box>
-
-          <Text>
-            {configData.result.貸付制度.caption.map(
-              (line: string, index: any) => (
-                <span key={index}>{line}</span>
-              )
-            )}
-            <Tooltip
-              label={configData.result.consultationDescription3}
-              isOpen={isLabelOpen}
-              bg="gray.600"
-            >
-              <InfoIcon
-                ml={1}
-                color="blue.500"
-                onMouseEnter={() => setIsLabelOpen(true)}
-                onMouseLeave={() => setIsLabelOpen(false)}
-                onClick={() => setIsLabelOpen(true)}
-              />
-            </Tooltip>
-          </Text>
-
-          <Box
-            bg="white"
-            borderRadius="xl"
-            pt={1}
-            pb={1}
-            pr={2}
-            pl={2}
-            m={2}
-            border="1px solid black"
-          >
-            {prefecture === '東京都' ? (
-              <Box>
-                {getSocialWelfareCouncilData().WebサイトURL ? (
-                  <Link
-                    href={getSocialWelfareCouncilData().WebサイトURL}
-                    color="blue.500"
-                    fontWeight={'semibold'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {getSocialWelfareCouncilData().施設名}
-                  </Link>
-                ) : (
-                  <Text fontWeight={'semibold'}>
-                    {getSocialWelfareCouncilData().施設名}
-                  </Text>
-                )}
-                <Text>〒{getSocialWelfareCouncilData().郵便番号}</Text>
-                <Link
-                  href={getSocialWelfareCouncilData().googleMapsURL}
-                  color="blue.500"
-                  fontWeight={'semibold'}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  地図を開く
-                  <ExternalLinkIcon ml={1} />
-                </Link>
-                <br />
-                <Text>
-                  TEL:
-                  <Link
-                    href={`tel:${getSocialWelfareCouncilData().電話番号}`}
-                    color="blue.500"
-                    fontWeight={'semibold'}
-                  >
-                    {getSocialWelfareCouncilData().電話番号}
-                  </Link>
-                </Text>
-              </Box>
-            ) : (
-              <Box>
-                <Text fontWeight={'semibold'}>社会福祉協議会の調べ方</Text>
-                <Text>
-                  下記のページからお住まいの社会福祉協議会を選択してください
-                </Text>
-                <Link
-                  href={aboutLink.link}
-                  color="blue.500"
-                  fontWeight={'semibold'}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  {aboutLink.title}
-                  <ExternalLinkIcon ml={1} />
-                </Link>
-              </Box>
-            )}
-          </Box>
-
-          <Box color="blue">
-            <a href={configData.result.貸付制度.reference}>詳細リンク</a>
-          </Box>
-
-          <Accordion allowMultiple>
-            {displayedResult &&
-              Object.values(displayedResult).map((val: any, index) => (
-                <AccordionItem key={index}>
-                  <h2>
-                    <AccordionButton>
-                      <AccordionIcon />
-                      <Box flex="1" textAlign="left">
-                        {val.name}
-                      </Box>
-                      <Box flex="1" textAlign="right">
-                        {/* １万円単位で表示 */}~{val.displayedMoney / 10_000}{' '}
-                        万{val.unit}
-                      </Box>
-                    </AccordionButton>
-                  </h2>
-                  <AccordionPanel pb={4}>
-                    {val.caption.map((line: string, index: any) => (
-                      <span key={index}>
-                        {line}
-                        <br />
-                      </span>
-                    ))}
-                    <Box color="blue">
-                      <a href={val.reference}>詳細リンク</a>
+          {Object.entries(configData.result.貸付制度).map(
+            (category: any, indexCategory: number) => (
+              <>
+                {Boolean(Object.keys(displayedResult[category[0]]).length) && (
+                  <Box mt={4} key={indexCategory}>
+                    <Box fontWeight="medium" mb={2}>
+                      {/* TODO: 他の貸付制度を追加したらconfigDataから読み込むようにする */}
+                      {category[0]}
                     </Box>
-                  </AccordionPanel>
-                </AccordionItem>
-              ))}
-          </Accordion>
+
+                    <Text>
+                      {category[1].caption.map(
+                        (line: string, indexCategory: any) => (
+                          <span key={indexCategory}>{line}</span>
+                        )
+                      )}
+                      {category[0] === '生活福祉資金貸付制度' && (
+                        <Tooltip
+                          label={configData.result.consultationDescription3}
+                          isOpen={isLabelOpen}
+                          bg="gray.600"
+                        >
+                          <InfoIcon
+                            ml={1}
+                            color="blue.500"
+                            onMouseEnter={() => setIsLabelOpen(true)}
+                            onMouseLeave={() => setIsLabelOpen(false)}
+                            onClick={() => setIsLabelOpen(true)}
+                          />
+                        </Tooltip>
+                      )}
+                    </Text>
+
+                    {category[0] === '生活福祉資金貸付制度' && (
+                      <Box
+                        bg="white"
+                        borderRadius="xl"
+                        pt={1}
+                        pb={1}
+                        pr={2}
+                        pl={2}
+                        m={2}
+                        border="1px solid black"
+                      >
+                        {prefecture === '東京都' ? (
+                          <Box>
+                            {getSocialWelfareCouncilData().WebサイトURL ? (
+                              <Link
+                                href={
+                                  getSocialWelfareCouncilData().WebサイトURL
+                                }
+                                color="blue.500"
+                                fontWeight={'semibold'}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {getSocialWelfareCouncilData().施設名}
+                              </Link>
+                            ) : (
+                              <Text fontWeight={'semibold'}>
+                                {getSocialWelfareCouncilData().施設名}
+                              </Text>
+                            )}
+                            <Text>
+                              〒{getSocialWelfareCouncilData().郵便番号}
+                            </Text>
+                            <Link
+                              href={getSocialWelfareCouncilData().googleMapsURL}
+                              color="blue.500"
+                              fontWeight={'semibold'}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              地図を開く
+                              <ExternalLinkIcon ml={1} />
+                            </Link>
+                            <br />
+                            <Text>
+                              TEL:
+                              <Link
+                                href={`tel:${
+                                  getSocialWelfareCouncilData().電話番号
+                                }`}
+                                color="blue.500"
+                                fontWeight={'semibold'}
+                              >
+                                {getSocialWelfareCouncilData().電話番号}
+                              </Link>
+                            </Text>
+                          </Box>
+                        ) : (
+                          <Box>
+                            <Text fontWeight={'semibold'}>
+                              社会福祉協議会の調べ方
+                            </Text>
+                            <Text>
+                              下記のページからお住まいの社会福祉協議会を選択してください
+                            </Text>
+                            <Link
+                              href={aboutLink.link}
+                              color="blue.500"
+                              fontWeight={'semibold'}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {aboutLink.title}
+                              <ExternalLinkIcon ml={1} />
+                            </Link>
+                          </Box>
+                        )}
+                      </Box>
+                    )}
+                    {category[1].reference && (
+                      <Box color="blue">
+                        <a href={category[1].reference}>詳細リンク</a>
+                      </Box>
+                    )}
+
+                    {/* 制度の算出結果 result value of loans */}
+                    <Accordion allowMultiple>
+                      {displayedResult[category[0]] &&
+                        Object.values(displayedResult[category[0]]).map(
+                          (val: any, index) => (
+                            <AccordionItem key={index}>
+                              <h2>
+                                <AccordionButton>
+                                  <AccordionIcon />
+                                  <Box flex="1" textAlign="left">
+                                    {val.name}
+                                  </Box>
+                                  <Box flex="1" textAlign="right">
+                                    {/* １万円単位で表示 */}~
+                                    {val.displayedMoney / 10_000} 万{val.unit}
+                                  </Box>
+                                </AccordionButton>
+                              </h2>
+                              <AccordionPanel pb={4}>
+                                {val.caption.map((line: string, index: any) => (
+                                  <span key={index}>
+                                    {line}
+                                    <br />
+                                  </span>
+                                ))}
+                                <Box color="blue">
+                                  <a href={val.reference}>詳細リンク</a>
+                                </Box>
+                              </AccordionPanel>
+                            </AccordionItem>
+                          )
+                        )}
+                    </Accordion>
+                  </Box>
+                )}
+              </>
+            )
+          )}
         </Box>
       )}
     </>

--- a/dashboard/src/components/result/loan.tsx
+++ b/dashboard/src/components/result/loan.tsx
@@ -2,24 +2,84 @@ import { useState, useEffect } from 'react';
 import {
   Box,
   Center,
+  Link,
   Accordion,
   AccordionItem,
   AccordionIcon,
   AccordionButton,
   AccordionPanel,
+  Text,
+  Tooltip,
 } from '@chakra-ui/react';
+import { InfoIcon, ExternalLinkIcon } from '@chakra-ui/icons';
 
 import configData from '../../config/app_config.json';
-import { currentDateAtom } from '../../state';
+import { data as SocialWelfareData } from '../../config/社会福祉協議会';
+import { currentDateAtom, householdAtom } from '../../state';
 import { useRecoilValue } from 'recoil';
 
 export const Loan = ({ result }: { result: any }) => {
   const [displayedResult, setDisplayedResult] = useState<any>();
   const currentDate = useRecoilValue(currentDateAtom);
+  const household = useRecoilValue(householdAtom);
+  const [isLabelOpen, setIsLabelOpen] = useState(false);
 
   interface Obj {
     [prop: string]: any; // これを記述することで、どんなプロパティでも持てるようになる
   }
+
+  const prefecture = household.世帯一覧.世帯1.居住都道府県[currentDate];
+
+  const city = household.世帯一覧.世帯1.居住市区町村[currentDate];
+
+  const getSocialWelfareCouncilData = () => {
+    if (
+      prefecture === '東京都' &&
+      SocialWelfareData.東京都.hasOwnProperty(city)
+    ) {
+      const {
+        施設名,
+        郵便番号,
+        所在地,
+        経度,
+        緯度,
+        座標系,
+        電話番号,
+        WebサイトURL,
+      } = SocialWelfareData.東京都[city];
+
+      return {
+        施設名,
+        郵便番号,
+        所在地,
+        経度,
+        緯度,
+        座標系,
+        電話番号,
+        WebサイトURL,
+        googleMapsURL: encodeURI(
+          `https://www.google.com/maps/search/${施設名}+${所在地}`
+        ),
+      };
+    }
+
+    return {
+      施設名: null,
+      郵便番号: null,
+      所在地: null,
+      経度: null,
+      緯度: null,
+      座標系: null,
+      電話番号: null,
+      WebサイトURL: '',
+      googleMapsURL: '',
+    };
+  };
+
+  const aboutLink = {
+    link: 'https://www.zcwvc.net/about/list.html',
+    title: '全国の社会福祉協議会一覧',
+  };
 
   useEffect(() => {
     const loanResult: Obj = {};
@@ -65,14 +125,97 @@ export const Loan = ({ result }: { result: any }) => {
             生活福祉資金貸付制度
           </Box>
 
-          {configData.result.貸付制度.caption.map(
-            (line: string, index: any) => (
-              <span key={index}>
-                {line}
+          <Text>
+            {configData.result.貸付制度.caption.map(
+              (line: string, index: any) => (
+                <span key={index}>{line}</span>
+              )
+            )}
+            <Tooltip
+              label={configData.result.consultationDescription3}
+              isOpen={isLabelOpen}
+              bg="gray.600"
+            >
+              <InfoIcon
+                ml={1}
+                color="blue.500"
+                onMouseEnter={() => setIsLabelOpen(true)}
+                onMouseLeave={() => setIsLabelOpen(false)}
+                onClick={() => setIsLabelOpen(true)}
+              />
+            </Tooltip>
+          </Text>
+
+          <Box
+            bg="white"
+            borderRadius="xl"
+            pt={1}
+            pb={1}
+            pr={2}
+            pl={2}
+            m={2}
+            border="1px solid black"
+          >
+            {prefecture === '東京都' ? (
+              <Box>
+                {getSocialWelfareCouncilData().WebサイトURL ? (
+                  <Link
+                    href={getSocialWelfareCouncilData().WebサイトURL}
+                    color="blue.500"
+                    fontWeight={'semibold'}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {getSocialWelfareCouncilData().施設名}
+                  </Link>
+                ) : (
+                  <Text fontWeight={'semibold'}>
+                    {getSocialWelfareCouncilData().施設名}
+                  </Text>
+                )}
+                <Text>〒{getSocialWelfareCouncilData().郵便番号}</Text>
+                <Link
+                  href={getSocialWelfareCouncilData().googleMapsURL}
+                  color="blue.500"
+                  fontWeight={'semibold'}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  地図を開く
+                  <ExternalLinkIcon ml={1} />
+                </Link>
                 <br />
-              </span>
-            )
-          )}
+                <Text>
+                  TEL:
+                  <Link
+                    href={`tel:${getSocialWelfareCouncilData().電話番号}`}
+                    color="blue.500"
+                    fontWeight={'semibold'}
+                  >
+                    {getSocialWelfareCouncilData().電話番号}
+                  </Link>
+                </Text>
+              </Box>
+            ) : (
+              <Box>
+                <Text fontWeight={'semibold'}>社会福祉協議会の調べ方</Text>
+                <Text>
+                  下記のページからお住まいの社会福祉協議会を選択してください
+                </Text>
+                <Link
+                  href={aboutLink.link}
+                  color="blue.500"
+                  fontWeight={'semibold'}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {aboutLink.title}
+                  <ExternalLinkIcon ml={1} />
+                </Link>
+              </Box>
+            )}
+          </Box>
+
           <Box color="blue">
             <a href={configData.result.貸付制度.reference}>詳細リンク</a>
           </Box>

--- a/dashboard/src/components/result/loan.tsx
+++ b/dashboard/src/components/result/loan.tsx
@@ -1,85 +1,21 @@
 import { useState, useEffect } from 'react';
-import {
-  Box,
-  Center,
-  Link,
-  Accordion,
-  AccordionItem,
-  AccordionIcon,
-  AccordionButton,
-  AccordionPanel,
-  Text,
-  Tooltip,
-} from '@chakra-ui/react';
-import { InfoIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import { Box, Center, Text, Tooltip } from '@chakra-ui/react';
+import { InfoIcon } from '@chakra-ui/icons';
 
 import configData from '../../config/app_config.json';
-import { data as SocialWelfareData } from '../../config/社会福祉協議会';
-import { currentDateAtom, householdAtom } from '../../state';
+import { currentDateAtom } from '../../state';
 import { useRecoilValue } from 'recoil';
+import { HelpDesk } from './helpDesk';
+import { LoanAccordion } from './loanAccordion';
 
 export const Loan = ({ result }: { result: any }) => {
   const [displayedResult, setDisplayedResult] = useState<any>();
   const currentDate = useRecoilValue(currentDateAtom);
-  const household = useRecoilValue(householdAtom);
   const [isLabelOpen, setIsLabelOpen] = useState(false);
 
   interface Obj {
     [prop: string]: any; // これを記述することで、どんなプロパティでも持てるようになる
   }
-
-  const prefecture = household.世帯一覧.世帯1.居住都道府県[currentDate];
-
-  const city = household.世帯一覧.世帯1.居住市区町村[currentDate];
-
-  const getSocialWelfareCouncilData = () => {
-    if (
-      prefecture === '東京都' &&
-      SocialWelfareData.東京都.hasOwnProperty(city)
-    ) {
-      const {
-        施設名,
-        郵便番号,
-        所在地,
-        経度,
-        緯度,
-        座標系,
-        電話番号,
-        WebサイトURL,
-      } = SocialWelfareData.東京都[city];
-
-      return {
-        施設名,
-        郵便番号,
-        所在地,
-        経度,
-        緯度,
-        座標系,
-        電話番号,
-        WebサイトURL,
-        googleMapsURL: encodeURI(
-          `https://www.google.com/maps/search/${施設名}+${所在地}`
-        ),
-      };
-    }
-
-    return {
-      施設名: null,
-      郵便番号: null,
-      所在地: null,
-      経度: null,
-      緯度: null,
-      座標系: null,
-      電話番号: null,
-      WebサイトURL: '',
-      googleMapsURL: '',
-    };
-  };
-
-  const aboutLink = {
-    link: 'https://www.zcwvc.net/about/list.html',
-    title: '全国の社会福祉協議会一覧',
-  };
 
   useEffect(() => {
     const loanResult: Obj = {};
@@ -107,7 +43,6 @@ export const Loan = ({ result }: { result: any }) => {
           }
         }
       }
-      console.log(loanResult);
       setDisplayedResult(loanResult);
       console.log(`display ${JSON.stringify(displayedResult)}`);
     }
@@ -115,7 +50,7 @@ export const Loan = ({ result }: { result: any }) => {
 
   return (
     <>
-      {displayedResult && Object.keys(displayedResult).length > 0 && (
+      {displayedResult && (
         <Box bg="white" borderRadius="xl" p={4} mb={4} ml={4} mr={4}>
           <Center
             fontSize={configData.style.subTitleFontSize}
@@ -125,10 +60,10 @@ export const Loan = ({ result }: { result: any }) => {
             {configData.result.loanDescription}
           </Center>
           {Object.entries(configData.result.貸付制度).map(
-            (category: any, indexCategory: number) => (
-              <>
+            (category: any, index: number) => (
+              <Box key={index}>
                 {Boolean(Object.keys(displayedResult[category[0]]).length) && (
-                  <Box mt={4} key={indexCategory}>
+                  <Box mt={4}>
                     <Box fontWeight="medium" mb={2}>
                       {/* TODO: 他の貸付制度を追加したらconfigDataから読み込むようにする */}
                       {category[0]}
@@ -136,8 +71,8 @@ export const Loan = ({ result }: { result: any }) => {
 
                     <Text>
                       {category[1].caption.map(
-                        (line: string, indexCategory: any) => (
-                          <span key={indexCategory}>{line}</span>
+                        (line: string, indexLine: any) => (
+                          <span key={indexLine}>{line}</span>
                         )
                       )}
                       {category[0] === '生活福祉資金貸付制度' && (
@@ -158,126 +93,20 @@ export const Loan = ({ result }: { result: any }) => {
                     </Text>
 
                     {category[0] === '生活福祉資金貸付制度' && (
-                      <Box
-                        bg="white"
-                        borderRadius="xl"
-                        pt={1}
-                        pb={1}
-                        pr={2}
-                        pl={2}
-                        m={2}
-                        border="1px solid black"
-                      >
-                        {prefecture === '東京都' ? (
-                          <Box>
-                            {getSocialWelfareCouncilData().WebサイトURL ? (
-                              <Link
-                                href={
-                                  getSocialWelfareCouncilData().WebサイトURL
-                                }
-                                color="blue.500"
-                                fontWeight={'semibold'}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                {getSocialWelfareCouncilData().施設名}
-                              </Link>
-                            ) : (
-                              <Text fontWeight={'semibold'}>
-                                {getSocialWelfareCouncilData().施設名}
-                              </Text>
-                            )}
-                            <Text>
-                              〒{getSocialWelfareCouncilData().郵便番号}
-                            </Text>
-                            <Link
-                              href={getSocialWelfareCouncilData().googleMapsURL}
-                              color="blue.500"
-                              fontWeight={'semibold'}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              地図を開く
-                              <ExternalLinkIcon ml={1} />
-                            </Link>
-                            <br />
-                            <Text>
-                              TEL:
-                              <Link
-                                href={`tel:${
-                                  getSocialWelfareCouncilData().電話番号
-                                }`}
-                                color="blue.500"
-                                fontWeight={'semibold'}
-                              >
-                                {getSocialWelfareCouncilData().電話番号}
-                              </Link>
-                            </Text>
-                          </Box>
-                        ) : (
-                          <Box>
-                            <Text fontWeight={'semibold'}>
-                              社会福祉協議会の調べ方
-                            </Text>
-                            <Text>
-                              下記のページからお住まいの社会福祉協議会を選択してください
-                            </Text>
-                            <Link
-                              href={aboutLink.link}
-                              color="blue.500"
-                              fontWeight={'semibold'}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {aboutLink.title}
-                              <ExternalLinkIcon ml={1} />
-                            </Link>
-                          </Box>
-                        )}
-                      </Box>
+                      <HelpDesk></HelpDesk>
                     )}
                     {category[1].reference && (
-                      <Box color="blue">
+                      <Box color="blue" mb={2}>
                         <a href={category[1].reference}>詳細リンク</a>
                       </Box>
                     )}
 
-                    {/* 制度の算出結果 result value of loans */}
-                    <Accordion allowMultiple>
-                      {displayedResult[category[0]] &&
-                        Object.values(displayedResult[category[0]]).map(
-                          (val: any, index) => (
-                            <AccordionItem key={index}>
-                              <h2>
-                                <AccordionButton>
-                                  <AccordionIcon />
-                                  <Box flex="1" textAlign="left">
-                                    {val.name}
-                                  </Box>
-                                  <Box flex="1" textAlign="right">
-                                    {/* １万円単位で表示 */}~
-                                    {val.displayedMoney / 10_000} 万{val.unit}
-                                  </Box>
-                                </AccordionButton>
-                              </h2>
-                              <AccordionPanel pb={4}>
-                                {val.caption.map((line: string, index: any) => (
-                                  <span key={index}>
-                                    {line}
-                                    <br />
-                                  </span>
-                                ))}
-                                <Box color="blue">
-                                  <a href={val.reference}>詳細リンク</a>
-                                </Box>
-                              </AccordionPanel>
-                            </AccordionItem>
-                          )
-                        )}
-                    </Accordion>
+                    <LoanAccordion
+                      loanResult={displayedResult[category[0]]}
+                    ></LoanAccordion>
                   </Box>
                 )}
-              </>
+              </Box>
             )
           )}
         </Box>

--- a/dashboard/src/components/result/loanAccordion.tsx
+++ b/dashboard/src/components/result/loanAccordion.tsx
@@ -1,0 +1,46 @@
+import {
+  Box,
+  Accordion,
+  AccordionItem,
+  AccordionIcon,
+  AccordionButton,
+  AccordionPanel,
+} from '@chakra-ui/react';
+
+// 制度の算出結果 result value of loans
+export const LoanAccordion = ({ loanResult }: { loanResult: any }) => {
+  return (
+    <>
+      <Accordion allowMultiple>
+        {loanResult &&
+          Object.values(loanResult).map((val: any, index) => (
+            <AccordionItem key={index}>
+              <h2>
+                <AccordionButton>
+                  <AccordionIcon />
+                  <Box flex="1" textAlign="left">
+                    {val.name}
+                  </Box>
+                  <Box flex="1" textAlign="right">
+                    {/* １万円単位で表示 */}~{val.displayedMoney / 10_000} 万
+                    {val.unit}
+                  </Box>
+                </AccordionButton>
+              </h2>
+              <AccordionPanel pb={4}>
+                {val.caption.map((line: string, index: any) => (
+                  <span key={index}>
+                    {line}
+                    <br />
+                  </span>
+                ))}
+                <Box color="blue">
+                  <a href={val.reference}>詳細リンク</a>
+                </Box>
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+      </Accordion>
+    </>
+  );
+};

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -183,9 +183,17 @@ export const Result = () => {
             text={
               isSimpleCalculation
                 ? configData.calculationForm.simpleCalculation
+                : isDisasterCalculation
+                ? configData.calculationForm.disasterCalculation
                 : configData.calculationForm.detailedCalculation
             }
-            colour={isSimpleCalculation ? 'teal' : 'blue'}
+            colour={
+              isSimpleCalculation
+                ? 'teal'
+                : isDisasterCalculation
+                ? 'orange'
+                : 'blue'
+            }
           />
 
           <Center

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useContext, useCallback } from 'react';
+import { useRef, useState, useEffect, useCallback } from 'react';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -18,7 +18,7 @@ import { useCalculate } from '../../hooks/calculate';
 import { Benefit } from './benefit';
 import { Loan } from './loan';
 import { CalculationLabel } from '../forms/calculationLabel';
-import { currentDateAtom } from '../../state';
+import { currentDateAtom, householdAtom } from '../../state';
 import { useRecoilValue } from 'recoil';
 
 const createFileName = (extension: string = '', ...names: string[]) => {
@@ -32,15 +32,16 @@ const createFileName = (extension: string = '', ...names: string[]) => {
 export const Result = () => {
   const location = useLocation();
   // TODO: decode household from URL
-  const { household, isSimpleCalculation } = location.state as {
-    household: any;
+  const { isSimpleCalculation, isDisasterCalculation } = location.state as {
     isSimpleCalculation: boolean;
+    isDisasterCalculation: boolean;
   };
 
   const [isLabelOpen, setIsLabelOpen] = useState(false);
   const navigate = useNavigate();
 
   const currentDate = useRecoilValue(currentDateAtom);
+  const household = useRecoilValue(householdAtom);
   const [result, calculate] = useCalculate();
   const [isDisplayChat, setIsDisplayChat] = useState('none');
 
@@ -54,6 +55,7 @@ export const Result = () => {
         navigate('/response-error', {
           state: {
             isSimpleCalculation: isSimpleCalculation,
+            isDisasterCalculation: isDisasterCalculation,
           },
         });
       });

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -1,19 +1,9 @@
 import { useRef, useState, useEffect, useCallback } from 'react';
 import { Link as RouterLink, useLocation, useNavigate } from 'react-router-dom';
-import {
-  Box,
-  Center,
-  Button,
-  Spinner,
-  Text,
-  Tooltip,
-  Link,
-} from '@chakra-ui/react';
-import { InfoIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import { Box, Center, Button, Spinner, Text } from '@chakra-ui/react';
 import * as htmlToImage from 'html-to-image';
 
 import configData from '../../config/app_config.json';
-import { data as SocialWelfareData } from '../../config/社会福祉協議会';
 import { useCalculate } from '../../hooks/calculate';
 import { Benefit } from './benefit';
 import { Loan } from './loan';
@@ -37,7 +27,6 @@ export const Result = () => {
     isDisasterCalculation: boolean;
   };
 
-  const [isLabelOpen, setIsLabelOpen] = useState(false);
   const navigate = useNavigate();
 
   const currentDate = useRecoilValue(currentDateAtom);
@@ -100,59 +89,6 @@ export const Result = () => {
     }
   };
 
-  const prefecture = household.世帯一覧.世帯1.居住都道府県[currentDate];
-
-  const city = household.世帯一覧.世帯1.居住市区町村[currentDate];
-
-  const getSocialWelfareCouncilData = () => {
-    if (
-      prefecture === '東京都' &&
-      SocialWelfareData.東京都.hasOwnProperty(city)
-    ) {
-      const {
-        施設名,
-        郵便番号,
-        所在地,
-        経度,
-        緯度,
-        座標系,
-        電話番号,
-        WebサイトURL,
-      } = SocialWelfareData.東京都[city];
-
-      return {
-        施設名,
-        郵便番号,
-        所在地,
-        経度,
-        緯度,
-        座標系,
-        電話番号,
-        WebサイトURL,
-        googleMapsURL: encodeURI(
-          `https://www.google.com/maps/search/${施設名}+${所在地}`
-        ),
-      };
-    }
-
-    return {
-      施設名: null,
-      郵便番号: null,
-      所在地: null,
-      経度: null,
-      緯度: null,
-      座標系: null,
-      電話番号: null,
-      WebサイトURL: '',
-      googleMapsURL: '',
-    };
-  };
-
-  const aboutLink = {
-    link: 'https://www.zcwvc.net/about/list.html',
-    title: '全国の社会福祉協議会一覧',
-  };
-
   const displayChat = useCallback(async (sec: number = 5) => {
     const sleep = (second: number) =>
       new Promise((resolve) => setTimeout(resolve, second * 1000));
@@ -207,105 +143,6 @@ export const Result = () => {
 
           <Benefit result={result} />
           <Loan result={result} />
-
-          {/* // 生活福祉資金貸付制度の結果欄に社会福祉協議会の説明ツールチップ、問い合わせ先説明欄を移行
-          <Center pr={4} pl={4} pb={2}>
-            <Text color="blue.900" fontSize="1.3em" fontWeight="semibold">
-              {configData.result.consultationDescription1}
-            </Text>
-          </Center>
-          <Center pr={4} pl={4} pb={4}>
-            <Text>
-              {configData.result.consultationDescription2}
-              <Tooltip
-                label={configData.result.consultationDescription3}
-                isOpen={isLabelOpen}
-                bg="gray.600"
-              >
-                <InfoIcon
-                  ml={1}
-                  color="blue.500"
-                  onMouseEnter={() => setIsLabelOpen(true)}
-                  onMouseLeave={() => setIsLabelOpen(false)}
-                  onClick={() => setIsLabelOpen(true)}
-                />
-              </Tooltip>
-            </Text>
-          </Center>
-          
-
-          <Center pr={4} pl={4} pb={2}>
-            <Box
-              bg="white"
-              borderRadius="xl"
-              w="100%"
-              pt={4}
-              pb={4}
-              pr={4}
-              pl={4}
-              border="1px solid black"
-            >
-              {prefecture === '東京都' ? (
-                <Box>
-                  {getSocialWelfareCouncilData().WebサイトURL ? (
-                    <Link
-                      href={getSocialWelfareCouncilData().WebサイトURL}
-                      color="blue.500"
-                      fontWeight={'semibold'}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {getSocialWelfareCouncilData().施設名}
-                    </Link>
-                  ) : (
-                    <Text fontWeight={'semibold'}>
-                      {getSocialWelfareCouncilData().施設名}
-                    </Text>
-                  )}
-                  <Text>〒{getSocialWelfareCouncilData().郵便番号}</Text>
-                  <Link
-                    href={getSocialWelfareCouncilData().googleMapsURL}
-                    color="blue.500"
-                    fontWeight={'semibold'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    地図を開く
-                    <ExternalLinkIcon ml={1} />
-                  </Link>
-                  <br />
-                  <Text>
-                    TEL:
-                    <Link
-                      href={`tel:${getSocialWelfareCouncilData().電話番号}`}
-                      color="blue.500"
-                      fontWeight={'semibold'}
-                    >
-                      {getSocialWelfareCouncilData().電話番号}
-                    </Link>
-                  </Text>
-                </Box>
-              ) : (
-                <Box>
-                  <Text fontWeight={'semibold'}>社会福祉協議会の調べ方</Text>
-                  <Text>
-                    下記のページからお住まいの社会福祉協議会を選択してください
-                  </Text>
-                  <Link
-                    href={aboutLink.link}
-                    color="blue.500"
-                    fontWeight={'semibold'}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {aboutLink.title}
-                    <ExternalLinkIcon ml={1} />
-                  </Link>
-                </Box>
-              )}
-            </Box>
-          </Center>
-          */}
 
           <Center pr={4} pl={4} pb={2}>
             <Text color="blue.900">

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -307,6 +307,11 @@ export const Result = () => {
           </Center>
           */}
 
+          <Center pr={4} pl={4} pb={2}>
+            <Text color="blue.900">
+              {configData.result.consultationDescription4}
+            </Text>
+          </Center>
           <Center pr={4} pl={4} pb={4}>
             <Button
               as={RouterLink}

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -208,6 +208,7 @@ export const Result = () => {
           <Benefit result={result} />
           <Loan result={result} />
 
+          {/* // 生活福祉資金貸付制度の結果欄に社会福祉協議会の説明ツールチップ、問い合わせ先説明欄を移行
           <Center pr={4} pl={4} pb={2}>
             <Text color="blue.900" fontSize="1.3em" fontWeight="semibold">
               {configData.result.consultationDescription1}
@@ -231,6 +232,7 @@ export const Result = () => {
               </Tooltip>
             </Text>
           </Center>
+          
 
           <Center pr={4} pl={4} pb={2}>
             <Box
@@ -303,6 +305,7 @@ export const Result = () => {
               )}
             </Box>
           </Center>
+          */}
 
           <Center pr={4} pl={4} pb={4}>
             <Button

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -141,21 +141,24 @@
         "児童育成手当": {
           "unit": "円/月",
           "caption": ["ひとり親家庭に給付される手当"],
-          "reference": "https://www.fukushi.metro.tokyo.lg.jp/kodomo/kosodate/teate/zidouikuseiteate.html"
+          "reference": "https://www.fukushi.metro.tokyo.lg.jp/kodomo/kosodate/teate/zidouikuseiteate.html",
+          "local": "東京都"
         },
         "障害児童育成手当": {
           "unit": "円/月",
           "caption": [
             "精神又は身体に障害をもつ20歳未満の児童を養育している方に給付される手当"
           ],
-          "reference": "https://www.fukushi.metro.tokyo.lg.jp/kodomo/kosodate/teate/zidouikuseiteate.html"
+          "reference": "https://www.fukushi.metro.tokyo.lg.jp/kodomo/kosodate/teate/zidouikuseiteate.html",
+          "local": "東京都"
         },
         "重度心身障害者手当": {
           "unit": "円/月",
           "caption": [
             "精神又は身体に重度の障害を持ち、常時複雑な介護を必要とする方に給付される手当"
           ],
-          "reference": "https://www.fukushi.metro.tokyo.lg.jp/shinsho/teate/juudo.html"
+          "reference": "https://www.fukushi.metro.tokyo.lg.jp/shinsho/teate/juudo.html",
+          "local": "東京都"
         },
         "生活保護": {
           "unit": "円/月",
@@ -192,7 +195,8 @@
             "利子：保証人あり 無利子",
             "　　　保証人なし 年1.5%"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "一時生活再建費": {
           "unit": "円 　",
@@ -202,7 +206,8 @@
             "利子：保証人あり 無利子",
             "　　　保証人なし 年1.5%"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "福祉費": {
           "unit": "円 　",
@@ -212,7 +217,8 @@
             "利子：保証人あり 無利子",
             "　　　保証人なし 年1.5%"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "緊急小口資金": {
           "unit": "円 　",
@@ -221,7 +227,8 @@
             "返済期限：1年以内",
             "利子：無利子"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "住宅入居費": {
           "unit": "円 　",
@@ -231,7 +238,8 @@
             "利子：保証人あり 無利子",
             "　　　保証人なし 年1.5%"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "教育支援費": {
           "unit": "円/月",
@@ -240,7 +248,8 @@
             "返済期限：20年以内",
             "利子：無利子"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "就学支度費": {
           "unit": "円 　",
@@ -249,7 +258,8 @@
             "返済期限：20年以内",
             "利子：無利子"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "不動産担保型生活資金": {
           "unit": "円/月",
@@ -257,7 +267,8 @@
             "不動産を担保として借りられる生活資金",
             "利子：年3%、または長期プライムレートのいずれか低い利率"
           ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
+          "category": "生活福祉資金貸付制度"
         },
         "受験生チャレンジ支援貸付": {
           "unit": "円 　",
@@ -266,7 +277,8 @@
             "返済期限：5年以内（高校・大学等に入学した場合、返済が免除されます）",
             "利子：無利子"
           ],
-          "reference": "https://jukenchallenge.jp"
+          "reference": "https://jukenchallenge.jp",
+          "local": "東京都"
         }
       }
     }

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -89,8 +89,9 @@
     "spouseDescription": "配偶者について",
     "childrenDescription": "人目の子ども",
     "parentDescription": "同居している親または祖父母",
-    "simpleCalculation": "かんたん計算",
-    "detailedCalculation": "くわしく計算"
+    "simpleCalculation": "かんたん見積もり",
+    "detailedCalculation": "くわしく見積もり",
+    "disasterCalculation": "能登半島地震 被災者支援見積もり"
   },
   "result": {
     "topDescription": "計算結果",

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -94,7 +94,7 @@
     "disasterCalculation": "能登半島地震 被災者支援見積もり"
   },
   "result": {
-    "topDescription": "計算結果",
+    "topDescription": "見積もり結果",
     "detailedCalculationDescription": "「くわしく計算」モードでは、より正確な結果が表示されます。金額が上がる場合もあります。",
     "questionExamplesButtonText": "窓口での質問例",
     "screenshotButtonText": "このページを画像で保存",

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -111,18 +111,18 @@
     "benefitDescription": "給付される可能性のあるお金",
     "給付制度": {
       "caption": [
-        "詳細な給付条件や申請方法については市町村の窓口にお問い合わせください。"
+        "詳細な給付条件や申請方法については市町村の役所窓口にお問い合わせください。"
       ],
       "制度一覧": {
         "児童手当": {
           "unit": "円/月",
           "caption": ["中学校卒業までの児童を養育している方に給付される手当"],
-          "reference": "https://www8.cao.go.jp/shoushi/jidouteate/annai.html"
+          "reference": "https://www.cfa.go.jp/policies/kokoseido/jidouteate/annai/"
         },
         "児童扶養手当": {
           "unit": "円/月",
           "caption": ["ひとり親家庭に給付される手当"],
-          "reference": "https://www.mhlw.go.jp/bunya/kodomo/osirase/100526-1.html"
+          "reference": "https://www.cfa.go.jp/policies/hitori-oya/fuyou-teate/"
         },
         "特別児童扶養手当": {
           "unit": "円/月",
@@ -180,105 +180,106 @@
     },
     "loanDescription": "借りられる可能性のあるお金",
     "貸付制度": {
-      "caption": [
-        "原則無利子・無担保でお金を借りられ、サポーターの支援も受けられる制度。",
-        "詳細は市町村社会福祉協議会または都道府県社会福祉協議会にお問い合わせください。"
-      ],
-      "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/index.html",
-      "制度一覧": {
-        "生活支援費": {
-          "unit": "円/月",
-          "caption": [
-            "生活再建までの間に必要な生活費用",
-            "貸付期間:原則3ヶ月（最長12ヶ月）",
-            "返済期限：10年以内",
-            "利子：保証人あり 無利子",
-            "　　　保証人なし 年1.5%"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "一時生活再建費": {
-          "unit": "円 　",
-          "caption": [
-            "生活再建までの間に一時的に必要な生活費用",
-            "返済期限：10年以内",
-            "利子：保証人あり 無利子",
-            "　　　保証人なし 年1.5%"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "福祉費": {
-          "unit": "円 　",
-          "caption": [
-            "様々な用途で必要なお金",
-            "返済期限：20年以内",
-            "利子：保証人あり 無利子",
-            "　　　保証人なし 年1.5%"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "緊急小口資金": {
-          "unit": "円 　",
-          "caption": [
-            "緊急かつ一時的に生計の維持が困難となった場合に借りられる資金",
-            "返済期限：1年以内",
-            "利子：無利子"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "住宅入居費": {
-          "unit": "円 　",
-          "caption": [
-            "家の賃貸契約を結ぶために必要な費用",
-            "返済期限：10年以内",
-            "利子：保証人あり 無利子",
-            "　　　保証人なし 年1.5%"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "教育支援費": {
-          "unit": "円/月",
-          "caption": [
-            "高校、大学等で学ぶために必要な費用",
-            "返済期限：20年以内",
-            "利子：無利子"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "就学支度費": {
-          "unit": "円 　",
-          "caption": [
-            "高校、大学等の入学に必要な費用",
-            "返済期限：20年以内",
-            "利子：無利子"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "不動産担保型生活資金": {
-          "unit": "円/月",
-          "caption": [
-            "不動産を担保として借りられる生活資金",
-            "利子：年3%、または長期プライムレートのいずれか低い利率"
-          ],
-          "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html",
-          "category": "生活福祉資金貸付制度"
-        },
-        "受験生チャレンジ支援貸付": {
-          "unit": "円 　",
-          "caption": [
-            "高校や大学等の受験料や塾などの受講料",
-            "返済期限：5年以内（高校・大学等に入学した場合、返済が免除されます）",
-            "利子：無利子"
-          ],
-          "reference": "https://jukenchallenge.jp",
-          "local": "東京都"
+      "生活福祉資金貸付制度": {
+        "caption": [
+          "原則無利子・無担保でお金を借りられ、サポーターの支援も受けられる制度。",
+          "詳細は市町村社会福祉協議会または都道府県社会福祉協議会にお問い合わせください。"
+        ],
+        "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/index.html",
+        "制度一覧": {
+          "生活支援費": {
+            "unit": "円/月",
+            "caption": [
+              "生活再建までの間に必要な生活費用",
+              "貸付期間:原則3ヶ月（最長12ヶ月）",
+              "返済期限：10年以内",
+              "利子：保証人あり 無利子",
+              "　　　保証人なし 年1.5%"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          },
+          "一時生活再建費": {
+            "unit": "円 　",
+            "caption": [
+              "生活再建までの間に一時的に必要な生活費用",
+              "返済期限：10年以内",
+              "利子：保証人あり 無利子",
+              "　　　保証人なし 年1.5%"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          },
+          "福祉費": {
+            "unit": "円 　",
+            "caption": [
+              "様々な用途で必要なお金",
+              "返済期限：20年以内",
+              "利子：保証人あり 無利子",
+              "　　　保証人なし 年1.5%"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          },
+          "緊急小口資金": {
+            "unit": "円 　",
+            "caption": [
+              "緊急かつ一時的に生計の維持が困難となった場合に借りられる資金",
+              "返済期限：1年以内",
+              "利子：無利子"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          },
+          "住宅入居費": {
+            "unit": "円 　",
+            "caption": [
+              "家の賃貸契約を結ぶために必要な費用",
+              "返済期限：10年以内",
+              "利子：保証人あり 無利子",
+              "　　　保証人なし 年1.5%"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          },
+          "教育支援費": {
+            "unit": "円/月",
+            "caption": [
+              "高校、大学等で学ぶために必要な費用",
+              "返済期限：20年以内",
+              "利子：無利子"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          },
+          "就学支度費": {
+            "unit": "円 　",
+            "caption": [
+              "高校、大学等の入学に必要な費用",
+              "返済期限：20年以内",
+              "利子：無利子"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          },
+          "不動産担保型生活資金": {
+            "unit": "円/月",
+            "caption": [
+              "不動産を担保として借りられる生活資金",
+              "利子：年3%、または長期プライムレートのいずれか低い利率"
+            ],
+            "reference": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/hukushi_kaigo/seikatsuhogo/seikatsu-fukushi-shikin1/kashitsukejoken.html"
+          }
+        }
+      },
+      "その他": {
+        "caption": [
+          "詳細な貸付条件や申請方法については市町村の役所窓口にお問い合わせください。"
+        ],
+        "制度一覧": {
+          "受験生チャレンジ支援貸付": {
+            "unit": "円 　",
+            "caption": [
+              "高校や大学等の受験料や塾などの受講料",
+              "返済期限：5年以内（高校・大学等に入学した場合、返済が免除されます）",
+              "利子：無利子"
+            ],
+            "reference": "https://jukenchallenge.jp",
+            "local": "東京都"
+          }
         }
       }
     }

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -6,7 +6,7 @@
     },
     "Github": "https://github.com/project-inclusive/OpenFisca-Japan",
     "contact": "https://www.poverty-prevention.net/",
-    "chatbot": "https://miibo.jp/chat/f791f806-10f2-493c-8ed5-0174ec3e483618afd9cdeff118?name=%E3%83%A4%E3%83%89%E3%82%AB%E3%83%AA%E3%81%8F%E3%82%93",
+    "chatbot": "https://miibo.jp/chat/b86882cc-35e6-4796-a880-b2148056299418ce92567e3f9?name=%E3%83%A4%E3%83%89%E3%82%AB%E3%83%AA%E3%81%8F%E3%82%93",
     "questionnaire_form": "https://forms.gle/fxztn7JGTuZ3v1mS9"
   },
   "style": {

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -101,6 +101,7 @@
     "consultationDescription1": "まずは近くの社会福祉協議会に相談してみませんか？",
     "consultationDescription2": "きっとあなたの相談に寄り添ってくれるはずです",
     "consultationDescription3": "社会福祉協議会はさまざまな福祉サービスや相談活動、市民と行政の橋渡しを行う民間組織です。他の制度や関係する窓口を紹介してもらえる可能性もあります。",
+    "consultationDescription4": "まずは窓口に相談してみませんか？ きっとあなたの相談に寄り添ってくれるはずです",
     "chatbotDescription": [
       "追加で知りたいことがあればヤドカリくんにも聞いてみましょう。"
     ],

--- a/openfisca_japan/variables/福祉/育児/児童扶養手当.py
+++ b/openfisca_japan/variables/福祉/育児/児童扶養手当.py
@@ -17,7 +17,7 @@ class 児童扶養手当_最大(Variable):
     entity = 世帯
     definition_period = DAY
     label = "保護者への児童扶養手当の最大額"
-    reference = "https://www.mhlw.go.jp/bunya/kodomo/osirase/100526-1.html"
+    reference = "https://www.cfa.go.jp/policies/hitori-oya/fuyou-teate/"
     documentation = """
     児童扶養手当制度
     """
@@ -56,7 +56,7 @@ class 児童扶養手当_最小(Variable):
     entity = 世帯
     definition_period = DAY
     label = "保護者への児童扶養手当の最小額"
-    reference = "https://www.mhlw.go.jp/bunya/kodomo/osirase/100526-1.html"
+    reference = "https://www.cfa.go.jp/policies/hitori-oya/fuyou-teate/"
     documentation = """
     児童扶養手当制度
     """
@@ -95,7 +95,7 @@ class 児童扶養手当の全部支給所得条件(Variable):
     entity = 世帯
     definition_period = DAY
     label = "保護者への児童扶養手当の全額支給所得条件"
-    reference = "https://www.mhlw.go.jp/bunya/kodomo/osirase/100526-1.html"
+    reference = "https://www.cfa.go.jp/policies/hitori-oya/fuyou-teate/"
     documentation = """
     児童扶養手当制度
     """
@@ -120,7 +120,7 @@ class 児童扶養手当の一部支給所得条件(Variable):
     entity = 世帯
     definition_period = DAY
     label = "保護者への児童扶養手当の一部支給所得条件"
-    reference = "https://www.mhlw.go.jp/bunya/kodomo/osirase/100526-1.html"
+    reference = "https://www.cfa.go.jp/policies/hitori-oya/fuyou-teate/"
     documentation = """
     児童扶養手当制度
     """
@@ -147,7 +147,7 @@ class 児童扶養手当の対象児童人数(Variable):
     entity = 世帯
     definition_period = DAY
     label = "保護者への児童扶養手当の対象児童人数"
-    reference = "https://www.mhlw.go.jp/bunya/kodomo/osirase/100526-1.html"
+    reference = "https://www.cfa.go.jp/policies/hitori-oya/fuyou-teate/"
     documentation = """
     児童扶養手当制度
     """


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は 能登半島地震被災者支援制度フォームを追加する
  - そのために トップページに「能登半島地震被災者支援制度見積もり」ボタン を追加した
  - 「能登半島地震被災者支援制度見積もり」ラベルを追加した。
  - トップページに見積もり対象制度一覧アコーディオンを追加した。
  - 結果ページの社会福祉協議会連絡先を貸付制度欄に移した。
  - 貸付制度を生活福祉資金貸付制度とその他に分類した。
  - 「計算」を「見積もり」に変更した。

## 動作確認

- [x] 追加|変更した部分の影響しそうな箇所をテスト|目視確認した
