### PR TITLE
被災者支援制度用フォームを追加

### DIFF
--- a/dashboard/src/components/forms/attributes/ChildrenNum.tsx
+++ b/dashboard/src/components/forms/attributes/ChildrenNum.tsx
@@ -13,6 +13,7 @@ import { useRecoilState } from 'recoil';
 import { householdAtom } from '../../../state';
 
 export const ChildrenNum = () => {
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
   const navigationType = useNavigationType();
   const [household, setHousehold] = useRecoilState(householdAtom);
   const [shownChildrenNum, setShownChildrenNum] = useState<string | number>('');
@@ -94,7 +95,7 @@ export const ChildrenNum = () => {
           isChecked={isChecked}
           onChange={onCheckChange}
         >
-          子どもがいる
+          {isDisasterCalculation && '存命の'}子どもがいる
         </Checkbox>
         {isChecked && (
           <FormControl mt={2} ml={4} mr={4} mb={4}>

--- a/dashboard/src/components/forms/attributes/DisasterDeath.tsx
+++ b/dashboard/src/components/forms/attributes/DisasterDeath.tsx
@@ -1,0 +1,162 @@
+import { useCallback, useState, useRef, useEffect } from 'react';
+import { useNavigationType } from 'react-router-dom';
+import {
+  Checkbox,
+  Box,
+  HStack,
+  Input,
+  FormControl,
+  FormLabel,
+} from '@chakra-ui/react';
+
+import { useRecoilValue, useRecoilState } from 'recoil';
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const DisasterDeath = () => {
+  const navigationType = useNavigationType();
+  const currentDate = useRecoilValue(currentDateAtom);
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const [shownMemberNum, setShownMemberNum] = useState<string | number>('');
+  const inputEl = useRef<HTMLInputElement>(null);
+
+  const [isChecked, setIsChecked] = useState(false);
+  const [isMaintainerChecked, setIsMaintainerChecked] = useState(false);
+
+  // debug
+  useEffect(() => {
+    const newHousehold = { ...household };
+    newHousehold.世帯一覧.世帯1.災害救助法の適用地域である = {
+      [currentDate]: true,
+    };
+    newHousehold.世帯一覧.世帯1.被災者生活再建支援法の適用地域である = {
+      [currentDate]: true,
+    };
+    setHousehold({ ...newHousehold });
+  }, []);
+
+  // 「災害で世帯員が亡くなった」チェックボックスの値が変更された時
+  const onCheckChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (!event.target.checked) {
+        const newHousehold = { ...household };
+        newHousehold.世帯一覧.世帯1.災害で死亡した世帯員の人数 = {
+          [currentDate]: 0,
+        };
+        newHousehold.世帯一覧.世帯1.災害で生計維持者が死亡した = {
+          [currentDate]: false,
+        };
+        setShownMemberNum('');
+        setHousehold({ ...newHousehold });
+      }
+      setIsChecked(event.target.checked);
+    },
+    []
+  );
+
+  // 「災害で世帯員が亡くなった」がチェックされたときに「亡くなった世帯員の数」フォームにフォーカス
+  useEffect(() => {
+    if (inputEl.current) {
+      inputEl.current.focus();
+    }
+  }, [isChecked]);
+
+  // 「亡くなった世帯員の数」フォームの変更時
+  const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    let memberNum = parseInt(event.currentTarget.value);
+    // 正の整数以外は0に変換
+    if (isNaN(memberNum) || memberNum < 1) {
+      memberNum = 1;
+      setShownMemberNum('');
+    } else {
+      setShownMemberNum(memberNum);
+    }
+
+    const newHousehold = { ...household };
+    newHousehold.世帯一覧.世帯1.災害で死亡した世帯員の人数 = {
+      [currentDate]: memberNum,
+    };
+    setHousehold({ ...newHousehold });
+  }, []);
+
+  // 生計維持者のチェックボックスの値が変更された時
+  const onMaintainerCheckChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const newHousehold = { ...household };
+      if (event.target.checked) {
+        newHousehold.世帯一覧.世帯1.災害で生計維持者が死亡した = {
+          [currentDate]: true,
+        };
+      } else {
+        newHousehold.世帯一覧.世帯1.災害で生計維持者が死亡した = {
+          [currentDate]: false,
+        };
+      }
+
+      setHousehold({ ...newHousehold });
+      setIsMaintainerChecked(event.target.checked);
+    },
+    []
+  );
+
+  // stored states set displayed value when page transition
+  useEffect(() => {
+    const householdObj = household.世帯一覧.世帯1;
+    if (
+      (householdObj.災害で死亡した世帯員の人数 &&
+        householdObj.災害で死亡した世帯員の人数[currentDate] > 0) ||
+      (householdObj.災害で生計維持者が死亡した &&
+        householdObj.災害で生計維持者が死亡した[currentDate])
+    ) {
+      setIsChecked(true);
+      setShownMemberNum(householdObj.災害で死亡した世帯員の人数[currentDate]);
+      setIsMaintainerChecked(
+        householdObj.災害で生計維持者が死亡した[currentDate]
+      );
+    }
+  }, [navigationType]);
+
+  return (
+    <>
+      <Box mb={4}>
+        <Checkbox
+          colorScheme="cyan"
+          isChecked={isChecked}
+          onChange={onCheckChange}
+        >
+          災害で世帯員が亡くなった
+        </Checkbox>
+        {isChecked && (
+          <FormControl mt={2} ml={4} mr={4} mb={4}>
+            <FormLabel fontWeight="Regular">亡くなった世帯員の数</FormLabel>
+            <HStack mb={4}>
+              <Input
+                type="number"
+                value={shownMemberNum}
+                pattern="[1-9]*"
+                onInput={(e) => {
+                  e.currentTarget.value = e.currentTarget.value.replace(
+                    /[^1-9]/g,
+                    ''
+                  );
+                }}
+                onChange={onChange}
+                width="9em"
+                ref={inputEl}
+              />
+              <Box>人</Box>
+            </HStack>
+
+            <Checkbox
+              isChecked={isMaintainerChecked}
+              onChange={onMaintainerCheckChange}
+              colorScheme="cyan"
+              mb={2}
+            >
+              生計維持者（世帯で最も年収が多い方）が亡くなった
+            </Checkbox>
+          </FormControl>
+        )}
+      </Box>
+    </>
+  );
+};

--- a/dashboard/src/components/forms/attributes/DisasterDeath.tsx
+++ b/dashboard/src/components/forms/attributes/DisasterDeath.tsx
@@ -46,6 +46,7 @@ export const DisasterDeath = () => {
           [currentDate]: false,
         };
         setShownMemberNum('');
+        setIsMaintainerChecked(false);
         setHousehold({ ...newHousehold });
       }
       setIsChecked(event.target.checked);
@@ -139,47 +140,45 @@ export const DisasterDeath = () => {
   }, [navigationType]);
 
   return (
-    <>
-      <Box mb={4}>
-        <Checkbox
-          colorScheme="cyan"
-          isChecked={isChecked}
-          onChange={onCheckChange}
-        >
-          災害で世帯員が亡くなった
-        </Checkbox>
-        {isChecked && (
-          <FormControl mt={2} ml={4} mr={4} mb={4}>
-            <FormLabel fontWeight="Regular">亡くなった世帯員の数</FormLabel>
-            <HStack mb={4}>
-              <Input
-                type="number"
-                value={shownMemberNum}
-                pattern="[0-9]*"
-                onInput={(e) => {
-                  e.currentTarget.value = e.currentTarget.value.replace(
-                    /[^0-9]/g,
-                    ''
-                  );
-                }}
-                onChange={onChange}
-                width="9em"
-                ref={inputEl}
-              />
-              <Box>人</Box>
-            </HStack>
+    <Box mb={4}>
+      <Checkbox
+        colorScheme="cyan"
+        isChecked={isChecked}
+        onChange={onCheckChange}
+      >
+        災害で世帯員が亡くなった
+      </Checkbox>
+      {isChecked && (
+        <FormControl mt={2} ml={4} mr={4} mb={4}>
+          <FormLabel fontWeight="Regular">亡くなった世帯員の数</FormLabel>
+          <HStack mb={4}>
+            <Input
+              type="number"
+              value={shownMemberNum}
+              pattern="[0-9]*"
+              onInput={(e) => {
+                e.currentTarget.value = e.currentTarget.value.replace(
+                  /[^0-9]/g,
+                  ''
+                );
+              }}
+              onChange={onChange}
+              width="9em"
+              ref={inputEl}
+            />
+            <Box>人</Box>
+          </HStack>
 
-            <Checkbox
-              isChecked={isMaintainerChecked}
-              onChange={onMaintainerCheckChange}
-              colorScheme="cyan"
-              mb={2}
-            >
-              生計維持者（世帯で最も年収が多い方）が亡くなった
-            </Checkbox>
-          </FormControl>
-        )}
-      </Box>
-    </>
+          <Checkbox
+            isChecked={isMaintainerChecked}
+            onChange={onMaintainerCheckChange}
+            colorScheme="cyan"
+            mb={2}
+          >
+            生計維持者（世帯で最も年収が多い方）が亡くなった
+          </Checkbox>
+        </FormControl>
+      )}
+    </Box>
   );
 };

--- a/dashboard/src/components/forms/attributes/DisasterDeath.tsx
+++ b/dashboard/src/components/forms/attributes/DisasterDeath.tsx
@@ -155,10 +155,10 @@ export const DisasterDeath = () => {
               <Input
                 type="number"
                 value={shownMemberNum}
-                pattern="[1-9]*"
+                pattern="[0-9]*"
                 onInput={(e) => {
                   e.currentTarget.value = e.currentTarget.value.replace(
-                    /[^1-9]/g,
+                    /[^0-9]/g,
                     ''
                   );
                 }}

--- a/dashboard/src/components/forms/attributes/DisasterDisability.tsx
+++ b/dashboard/src/components/forms/attributes/DisasterDisability.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useState, useEffect } from 'react';
+import { useNavigationType } from 'react-router-dom';
+import { Checkbox, Box } from '@chakra-ui/react';
+import { useRecoilValue, useRecoilState } from 'recoil';
+
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const DisasterDisability = ({ personName }: { personName: string }) => {
+  const navigationType = useNavigationType();
+  const currentDate = useRecoilValue(currentDateAtom);
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const [isChecked, setIsChecked] = useState(false);
+
+  // チェックボックスの値が変更された時
+  const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const newHousehold = { ...household };
+    if (event.target.checked) {
+      newHousehold.世帯員[personName].災害による重い後遺障害がある = {
+        [currentDate]: true,
+      };
+    } else {
+      newHousehold.世帯員[personName].災害による重い後遺障害がある = {
+        [currentDate]: false,
+      };
+    }
+    setHousehold({ ...newHousehold });
+    setIsChecked(event.target.checked);
+  }, []);
+
+  // stored states set displayed value when page transition
+  useEffect(() => {
+    const disasterDisabilityObj =
+      household.世帯員[personName].災害による重い後遺障害がある;
+    setIsChecked(disasterDisabilityObj && disasterDisabilityObj[currentDate]);
+  }, [navigationType]);
+
+  return (
+    <Box mb={4}>
+      <Checkbox colorScheme="cyan" isChecked={isChecked} onChange={onChange}>
+        災害による精神または身体の重い障害がある
+      </Checkbox>
+    </Box>
+  );
+};

--- a/dashboard/src/components/forms/attributes/DisasterInjuryPeriod.tsx
+++ b/dashboard/src/components/forms/attributes/DisasterInjuryPeriod.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useState, useEffect } from 'react';
+import { useNavigationType } from 'react-router-dom';
+import { Checkbox, Box } from '@chakra-ui/react';
+import { useRecoilValue, useRecoilState } from 'recoil';
+
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const DisasterInjuryPeriod = ({
+  personName,
+}: {
+  personName: string;
+}) => {
+  const navigationType = useNavigationType();
+  const currentDate = useRecoilValue(currentDateAtom);
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const [isChecked, setIsChecked] = useState(false);
+
+  // チェックボックスの値が変更された時
+  const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const newHousehold = { ...household };
+    if (event.target.checked) {
+      newHousehold.世帯員[personName].災害による負傷の療養期間 = {
+        [currentDate]: '一か月以上',
+      };
+    } else {
+      newHousehold.世帯員[personName].災害による負傷の療養期間 = {
+        [currentDate]: '無',
+      };
+    }
+    setHousehold({ ...newHousehold });
+    setIsChecked(event.target.checked);
+  }, []);
+
+  // stored states set displayed value when page transition
+  useEffect(() => {
+    const memberObj = household.世帯員[personName].災害による負傷の療養期間;
+    setIsChecked(memberObj && memberObj[currentDate] === '一か月以上');
+  }, [navigationType]);
+
+  return (
+    <Box mb={4}>
+      <Checkbox colorScheme="cyan" isChecked={isChecked} onChange={onChange}>
+        災害による負傷の療養期間が1ヶ月以上
+      </Checkbox>
+    </Box>
+  );
+};

--- a/dashboard/src/components/forms/attributes/HouseholdGoodsDamage.tsx
+++ b/dashboard/src/components/forms/attributes/HouseholdGoodsDamage.tsx
@@ -1,0 +1,43 @@
+import { useCallback, useState, useEffect } from 'react';
+import { useNavigationType } from 'react-router-dom';
+import { Checkbox, Box } from '@chakra-ui/react';
+import { useRecoilValue, useRecoilState } from 'recoil';
+
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const HouseholdGoodsDamage = () => {
+  const navigationType = useNavigationType();
+  const currentDate = useRecoilValue(currentDateAtom);
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const [isChecked, setIsChecked] = useState(false);
+
+  // チェックボックスの値が変更された時
+  const onChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const newHousehold = { ...household };
+    if (event.target.checked) {
+      newHousehold.世帯一覧.世帯1.家財の損害 = {
+        [currentDate]: '三分の一以上',
+      };
+    } else {
+      newHousehold.世帯一覧.世帯1.家財の損害 = {
+        [currentDate]: '無',
+      };
+    }
+    setHousehold({ ...newHousehold });
+    setIsChecked(event.target.checked);
+  }, []);
+
+  // stored states set displayed value when page transition
+  useEffect(() => {
+    const householdObj = household.世帯一覧.世帯1.家財の損害;
+    setIsChecked(householdObj && householdObj[currentDate] === '三分の一以上');
+  }, [navigationType]);
+
+  return (
+    <Box mb={4}>
+      <Checkbox colorScheme="cyan" isChecked={isChecked} onChange={onChange}>
+        家財の３分の１以上に損害がある
+      </Checkbox>
+    </Box>
+  );
+};

--- a/dashboard/src/components/forms/attributes/HousingDamage.tsx
+++ b/dashboard/src/components/forms/attributes/HousingDamage.tsx
@@ -35,26 +35,21 @@ export const HousingDamage = () => {
     []
   );
 
-  // 「あなた」の「子どもの数」が変更されたときに全ての子どもの身体障害者手帳等級が「無」に
-  // リセットされるため、コンボボックスも「なし」に戻す
   // stored states set displayed value when page transition
   useEffect(() => {
-    if (household.世帯員[personName].身体障害者手帳等級) {
+    if (household.世帯一覧.世帯1.住宅被害) {
       items.map((item, index) => {
-        if (
-          item[1] ===
-          household.世帯員[personName].身体障害者手帳等級[currentDate]
-        ) {
+        if (item[1] === household.世帯一覧.世帯1.住宅被害[currentDate]) {
           setSelectedItemIndex(index);
         }
       });
     }
-  }, [navigationType, household.世帯員[personName].身体障害者手帳等級]);
+  }, [navigationType, household.世帯一覧.世帯1.住宅被害]);
 
   return (
     <>
       <FormControl>
-        <FormLabel fontWeight="Regular">身体障害者手帳</FormLabel>
+        <FormLabel fontWeight="Regular">住宅被害</FormLabel>
         <Select
           value={selectedItemIndex}
           className="form-select"

--- a/dashboard/src/components/forms/attributes/HousingDamage.tsx
+++ b/dashboard/src/components/forms/attributes/HousingDamage.tsx
@@ -1,0 +1,73 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useNavigationType } from 'react-router-dom';
+import { Select, FormControl, FormLabel } from '@chakra-ui/react';
+
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const HousingDamage = () => {
+  const navigationType = useNavigationType();
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  // ラベルとOpenFiscaの表記違いを明記(pythonは数字を頭にした変数名をつけられない)
+  const items = [
+    ['', '無'],
+    ['中規模半壊（損害割合30%台）', '中規模半壊'],
+    ['大規模半壊（損害割合40%台）', '大規模半壊'],
+    ['全壊（損害割合50%以上）', '全壊'],
+    ['長期避難', '長期避難'],
+    ['解体', '解体'],
+    ['滅失または流失', '滅失または流失'],
+  ];
+  const [selectedItemIndex, setSelectedItemIndex] = useState(0);
+
+  // コンボボックスの値が変更された時
+  const onChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedItemIndex(parseInt(event.currentTarget.value));
+      const newHousehold = { ...household };
+      newHousehold.世帯一覧.世帯1.住宅被害 = {
+        [currentDate]: items[parseInt(event.currentTarget.value)][1],
+      };
+      setHousehold({ ...newHousehold });
+    },
+    []
+  );
+
+  // 「あなた」の「子どもの数」が変更されたときに全ての子どもの身体障害者手帳等級が「無」に
+  // リセットされるため、コンボボックスも「なし」に戻す
+  // stored states set displayed value when page transition
+  useEffect(() => {
+    if (household.世帯員[personName].身体障害者手帳等級) {
+      items.map((item, index) => {
+        if (
+          item[1] ===
+          household.世帯員[personName].身体障害者手帳等級[currentDate]
+        ) {
+          setSelectedItemIndex(index);
+        }
+      });
+    }
+  }, [navigationType, household.世帯員[personName].身体障害者手帳等級]);
+
+  return (
+    <>
+      <FormControl>
+        <FormLabel fontWeight="Regular">身体障害者手帳</FormLabel>
+        <Select
+          value={selectedItemIndex}
+          className="form-select"
+          onChange={onChange}
+          mb={3}
+        >
+          {items.map((item, index) => (
+            <option value={index} key={index}>
+              {item[0]}
+            </option>
+          ))}
+        </Select>
+      </FormControl>
+    </>
+  );
+};

--- a/dashboard/src/components/forms/attributes/HousingDamage.tsx
+++ b/dashboard/src/components/forms/attributes/HousingDamage.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { useNavigationType } from 'react-router-dom';
 import { Select, FormControl, FormLabel } from '@chakra-ui/react';
-
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { currentDateAtom, householdAtom } from '../../../state';
 
@@ -47,22 +46,20 @@ export const HousingDamage = () => {
   }, [navigationType, household.世帯一覧.世帯1.住宅被害]);
 
   return (
-    <>
-      <FormControl>
-        <FormLabel fontWeight="Regular">住宅被害</FormLabel>
-        <Select
-          value={selectedItemIndex}
-          className="form-select"
-          onChange={onChange}
-          mb={3}
-        >
-          {items.map((item, index) => (
-            <option value={index} key={index}>
-              {item[0]}
-            </option>
-          ))}
-        </Select>
-      </FormControl>
-    </>
+    <FormControl>
+      <FormLabel fontWeight="Regular">住宅被害</FormLabel>
+      <Select
+        value={selectedItemIndex}
+        className="form-select"
+        onChange={onChange}
+        mb={3}
+      >
+        {items.map((item, index) => (
+          <option value={index} key={index}>
+            {item[0]}
+          </option>
+        ))}
+      </Select>
+    </FormControl>
   );
 };

--- a/dashboard/src/components/forms/attributes/HousingReconstruction.tsx
+++ b/dashboard/src/components/forms/attributes/HousingReconstruction.tsx
@@ -1,0 +1,62 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useNavigationType } from 'react-router-dom';
+import { Select, FormControl, FormLabel } from '@chakra-ui/react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const HousingReconstruction = () => {
+  const navigationType = useNavigationType();
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  // ラベルとOpenFiscaの表記違いを明記(pythonは数字を頭にした変数名をつけられない)
+  const items = [
+    ['', '無'],
+    ['建設または購入', '建設または購入'],
+    ['補修', '補修'],
+    ['賃借', '賃借'],
+  ];
+  const [selectedItemIndex, setSelectedItemIndex] = useState(0);
+
+  // コンボボックスの値が変更された時
+  const onChange = useCallback(
+    (event: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedItemIndex(parseInt(event.currentTarget.value));
+      const newHousehold = { ...household };
+      newHousehold.世帯一覧.世帯1.住宅再建方法 = {
+        [currentDate]: items[parseInt(event.currentTarget.value)][1],
+      };
+      setHousehold({ ...newHousehold });
+    },
+    []
+  );
+
+  // stored states set displayed value when page transition
+  useEffect(() => {
+    if (household.世帯一覧.世帯1.住宅再建方法) {
+      items.map((item, index) => {
+        if (item[1] === household.世帯一覧.世帯1.住宅再建方法[currentDate]) {
+          setSelectedItemIndex(index);
+        }
+      });
+    }
+  }, [navigationType, household.世帯一覧.世帯1.住宅再建方法]);
+
+  return (
+    <FormControl>
+      <FormLabel fontWeight="Regular">住宅再建方法</FormLabel>
+      <Select
+        value={selectedItemIndex}
+        className="form-select"
+        onChange={onChange}
+        mb={3}
+      >
+        {items.map((item, index) => (
+          <option value={index} key={index}>
+            {item[0]}
+          </option>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};

--- a/dashboard/src/components/forms/attributes/Income.tsx
+++ b/dashboard/src/components/forms/attributes/Income.tsx
@@ -13,6 +13,7 @@ export const Income = ({
   personName: string;
   mustInput: boolean;
 }) => {
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
   const navigationType = useNavigationType();
   const currentDate = useRecoilValue(currentDateAtom);
 
@@ -59,7 +60,7 @@ export const Income = ({
       <FormControl>
         <FormLabel fontWeight="Regular">
           <HStack>
-            <Box>年収</Box>
+            <Box>{isDisasterCalculation && '被災前の'}年収</Box>
             {mustInput && (
               <Box color="red" fontSize="0.7em">
                 必須

--- a/dashboard/src/components/forms/attributes/ParentsNum.tsx
+++ b/dashboard/src/components/forms/attributes/ParentsNum.tsx
@@ -12,6 +12,7 @@ import { householdAtom } from '../../../state';
 import { useRecoilState } from 'recoil';
 
 export const ParentsNum = () => {
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
   const navigationType = useNavigationType();
   const [household, setHousehold] = useRecoilState(householdAtom);
   const [shownLivingToghtherNum, setShownLivingToghtherNum] = useState<
@@ -96,7 +97,7 @@ export const ParentsNum = () => {
           isChecked={isChecked}
           onChange={onCheckChange}
         >
-          親または祖父母と同居している
+          {isDisasterCalculation && '存命の'}親または祖父母と同居している
         </Checkbox>
         {isChecked && (
           <FormControl mt={2} ml={4} mr={4} mb={4}>

--- a/dashboard/src/components/forms/attributes/SpouseExists.tsx
+++ b/dashboard/src/components/forms/attributes/SpouseExists.tsx
@@ -6,6 +6,7 @@ import { currentDateAtom, householdAtom } from '../../../state';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 export const SpouseExists = () => {
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
   const currentDate = useRecoilValue(currentDateAtom);
 
   const [household, setHousehold] = useRecoilState(householdAtom);
@@ -47,7 +48,7 @@ export const SpouseExists = () => {
         onChange={onChange}
         mb={4}
       >
-        配偶者がいる（事実婚の場合も含む）
+        {isDisasterCalculation && '存命の'}配偶者がいる（事実婚の場合も含む）
       </Checkbox>
       <br></br>
     </>

--- a/dashboard/src/components/forms/children.tsx
+++ b/dashboard/src/components/forms/children.tsx
@@ -33,6 +33,7 @@ export const FormChildren = () => {
                   fontWeight="medium"
                   mb="0.5em"
                 >
+                  {isDisasterCalculation && '存命の'}
                   {index + 1}
                   {configData.calculationForm.childrenDescription}
                 </Center>

--- a/dashboard/src/components/forms/children.tsx
+++ b/dashboard/src/components/forms/children.tsx
@@ -1,5 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { Box, Center } from '@chakra-ui/react';
+import { useRecoilValue } from 'recoil';
+import { householdAtom } from '../../state';
 
 import configData from '../../config/app_config.json';
 import { Birthday } from './attributes/Birthday';
@@ -9,12 +11,12 @@ import { Working } from './attributes/Working';
 import { Recuperation } from './attributes/Recuperation';
 import { NursingHome } from './attributes/NursingHome';
 import { HighSchool } from './attributes/HighSchool';
-import { useRecoilValue } from 'recoil';
-import { householdAtom } from '../../state';
+import { DisasterDisability } from './attributes/DisasterDisability';
 
 export const FormChildren = () => {
   const location = useLocation();
   const isDetailedCalculation = location.pathname === '/calculate';
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
 
   const household = useRecoilValue(householdAtom);
 
@@ -47,6 +49,10 @@ export const FormChildren = () => {
                 )}
                 {isDetailedCalculation && (
                   <NursingHome personName={childName} />
+                )}
+
+                {isDisasterCalculation && (
+                  <DisasterDisability personName={childName} />
                 )}
               </Box>
             </div>

--- a/dashboard/src/components/forms/children.tsx
+++ b/dashboard/src/components/forms/children.tsx
@@ -12,6 +12,7 @@ import { Recuperation } from './attributes/Recuperation';
 import { NursingHome } from './attributes/NursingHome';
 import { HighSchool } from './attributes/HighSchool';
 import { DisasterDisability } from './attributes/DisasterDisability';
+import { DisasterInjuryPeriod } from './attributes/DisasterInjuryPeriod';
 
 export const FormChildren = () => {
   const location = useLocation();
@@ -41,6 +42,14 @@ export const FormChildren = () => {
                 ) : (
                   <AgeInput personName={childName} mustInput />
                 )}
+
+                {isDisasterCalculation && (
+                  <DisasterInjuryPeriod personName={childName} />
+                )}
+                {isDisasterCalculation && (
+                  <DisasterDisability personName={childName} />
+                )}
+
                 {isDetailedCalculation && <HighSchool personName={childName} />}
                 {isDetailedCalculation && <Working personName={childName} />}
                 {isDetailedCalculation && <Disability personName={childName} />}
@@ -49,10 +58,6 @@ export const FormChildren = () => {
                 )}
                 {isDetailedCalculation && (
                   <NursingHome personName={childName} />
-                )}
-
-                {isDisasterCalculation && (
-                  <DisasterDisability personName={childName} />
                 )}
               </Box>
             </div>

--- a/dashboard/src/components/forms/parents.tsx
+++ b/dashboard/src/components/forms/parents.tsx
@@ -33,6 +33,7 @@ export const FormParents = () => {
                   fontWeight="medium"
                   mb="0.5em"
                 >
+                  {isDisasterCalculation && '存命の'}
                   {configData.calculationForm.parentDescription}
                   {`（${index + 1}人目）`}
                 </Center>

--- a/dashboard/src/components/forms/parents.tsx
+++ b/dashboard/src/components/forms/parents.tsx
@@ -1,5 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { Box, Center } from '@chakra-ui/react';
+import { useRecoilValue } from 'recoil';
+import { householdAtom } from '../../state';
 
 import configData from '../../config/app_config.json';
 
@@ -10,18 +12,17 @@ import { Student } from './attributes/Student';
 import { Working } from './attributes/Working';
 import { Recuperation } from './attributes/Recuperation';
 import { NursingHome } from './attributes/NursingHome';
-import { useRecoilState } from 'recoil';
-import { householdAtom } from '../../state';
+import { DisasterDisability } from './attributes/DisasterDisability';
 
 export const FormParents = () => {
   const location = useLocation();
   const isDetailedCalculation = location.pathname === '/calculate';
-  const [household, setHousehold] = useRecoilState(householdAtom);
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
+  const household = useRecoilValue(householdAtom);
 
   return (
     <>
-      {isDetailedCalculation &&
-        household.世帯一覧.世帯1.祖父母一覧 &&
+      {household.世帯一覧.世帯1.祖父母一覧 &&
         household.世帯一覧.世帯1.祖父母一覧.map(
           (parentName: string, index: number) => (
             <div key={index}>
@@ -34,13 +35,27 @@ export const FormParents = () => {
                   {configData.calculationForm.parentDescription}
                   {`（${index + 1}人目）`}
                 </Center>
-                <Birthday personName={parentName} mustInput={true} />
-                <Income personName={parentName} mustInput={true} />
-                <Student personName={parentName} />
-                <Working personName={parentName} />
-                <Disability personName={parentName} />
-                <Recuperation personName={parentName} />
-                <NursingHome personName={parentName} />
+                {isDetailedCalculation && (
+                  <Birthday personName={parentName} mustInput={true} />
+                )}
+                {isDetailedCalculation && (
+                  <Income personName={parentName} mustInput={true} />
+                )}
+                {isDetailedCalculation && <Student personName={parentName} />}
+                {isDetailedCalculation && <Working personName={parentName} />}
+                {isDetailedCalculation && (
+                  <Disability personName={parentName} />
+                )}
+                {isDetailedCalculation && (
+                  <Recuperation personName={parentName} />
+                )}
+                {isDetailedCalculation && (
+                  <NursingHome personName={parentName} />
+                )}
+
+                {isDisasterCalculation && (
+                  <DisasterDisability personName={parentName} />
+                )}
               </Box>
             </div>
           )

--- a/dashboard/src/components/forms/parents.tsx
+++ b/dashboard/src/components/forms/parents.tsx
@@ -13,6 +13,7 @@ import { Working } from './attributes/Working';
 import { Recuperation } from './attributes/Recuperation';
 import { NursingHome } from './attributes/NursingHome';
 import { DisasterDisability } from './attributes/DisasterDisability';
+import { DisasterInjuryPeriod } from './attributes/DisasterInjuryPeriod';
 
 export const FormParents = () => {
   const location = useLocation();
@@ -35,6 +36,14 @@ export const FormParents = () => {
                   {configData.calculationForm.parentDescription}
                   {`（${index + 1}人目）`}
                 </Center>
+
+                {isDisasterCalculation && (
+                  <DisasterInjuryPeriod personName={parentName} />
+                )}
+                {isDisasterCalculation && (
+                  <DisasterDisability personName={parentName} />
+                )}
+
                 {isDetailedCalculation && (
                   <Birthday personName={parentName} mustInput={true} />
                 )}
@@ -51,10 +60,6 @@ export const FormParents = () => {
                 )}
                 {isDetailedCalculation && (
                   <NursingHome personName={parentName} />
-                )}
-
-                {isDisasterCalculation && (
-                  <DisasterDisability personName={parentName} />
                 )}
               </Box>
             </div>

--- a/dashboard/src/components/forms/spouse.tsx
+++ b/dashboard/src/components/forms/spouse.tsx
@@ -1,5 +1,7 @@
 import { useLocation } from 'react-router-dom';
 import { Box, Center } from '@chakra-ui/react';
+import { useRecoilValue } from 'recoil';
+import { householdAtom } from '../../state';
 
 import configData from '../../config/app_config.json';
 import { Birthday } from './attributes/Birthday';
@@ -11,13 +13,13 @@ import { Recuperation } from './attributes/Recuperation';
 import { NursingHome } from './attributes/NursingHome';
 import { Deposit } from './attributes/Deposit';
 import { SpouseExistsButSingleParent } from './attributes/SpouseExistsButSingleParent';
-import { useRecoilState } from 'recoil';
-import { householdAtom } from '../../state';
+import { DisasterDisability } from './attributes/DisasterDisability';
 
 export const FormSpouse = () => {
   const location = useLocation();
   const isDetailedCalculation = location.pathname === '/calculate';
-  const [household, setHousehold] = useRecoilState(householdAtom);
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
+  const household = useRecoilValue(householdAtom);
 
   const spouseName = '配偶者';
 
@@ -46,6 +48,10 @@ export const FormSpouse = () => {
             {isDetailedCalculation && <NursingHome personName={spouseName} />}
             {isDetailedCalculation && (
               <SpouseExistsButSingleParent personName={spouseName} />
+            )}
+
+            {isDisasterCalculation && (
+              <DisasterDisability personName={spouseName} />
             )}
           </Box>
         </>

--- a/dashboard/src/components/forms/spouse.tsx
+++ b/dashboard/src/components/forms/spouse.tsx
@@ -34,6 +34,7 @@ export const FormSpouse = () => {
               fontWeight="medium"
               mb="0.5em"
             >
+              {isDisasterCalculation && '存命の'}
               {configData.calculationForm.spouseDescription}
             </Center>
 

--- a/dashboard/src/components/forms/spouse.tsx
+++ b/dashboard/src/components/forms/spouse.tsx
@@ -14,6 +14,7 @@ import { NursingHome } from './attributes/NursingHome';
 import { Deposit } from './attributes/Deposit';
 import { SpouseExistsButSingleParent } from './attributes/SpouseExistsButSingleParent';
 import { DisasterDisability } from './attributes/DisasterDisability';
+import { DisasterInjuryPeriod } from './attributes/DisasterInjuryPeriod';
 
 export const FormSpouse = () => {
   const location = useLocation();
@@ -40,6 +41,14 @@ export const FormSpouse = () => {
               <Birthday personName={spouseName} mustInput={true} />
             )}
             <Income personName={spouseName} mustInput={true} />
+
+            {isDisasterCalculation && (
+              <DisasterInjuryPeriod personName={spouseName} />
+            )}
+            {isDisasterCalculation && (
+              <DisasterDisability personName={spouseName} />
+            )}
+
             {isDetailedCalculation && <Deposit personName={spouseName} />}
             {isDetailedCalculation && <Student personName={spouseName} />}
             {isDetailedCalculation && <Working personName={spouseName} />}
@@ -48,10 +57,6 @@ export const FormSpouse = () => {
             {isDetailedCalculation && <NursingHome personName={spouseName} />}
             {isDetailedCalculation && (
               <SpouseExistsButSingleParent personName={spouseName} />
-            )}
-
-            {isDisasterCalculation && (
-              <DisasterDisability personName={spouseName} />
             )}
           </Box>
         </>

--- a/dashboard/src/components/forms/you.tsx
+++ b/dashboard/src/components/forms/you.tsx
@@ -16,10 +16,12 @@ import { Recuperation } from './attributes/Recuperation';
 import { NursingHome } from './attributes/NursingHome';
 import { Pregnant } from './attributes/Pregnant';
 import { Deposit } from './attributes/Deposit';
+import { DisasterDeath } from './attributes/DisasterDeath';
 
 export const FormYou = () => {
   const location = useLocation();
   const isDetailedCalculation = location.pathname === '/calculate';
+  const isDisasterCalculation = location.pathname === '/calculate-disaster';
 
   const yourName = 'あなた';
   return (
@@ -37,6 +39,7 @@ export const FormYou = () => {
           <Birthday personName={yourName} mustInput={true} />
         )}
         <Income personName={yourName} mustInput={true} />
+        {isDisasterCalculation && <DisasterDeath />}
         {isDetailedCalculation && <Deposit personName={yourName} />}
         {isDetailedCalculation && <Student personName={yourName} />}
         {isDetailedCalculation && <Working personName={yourName} />}

--- a/dashboard/src/components/forms/you.tsx
+++ b/dashboard/src/components/forms/you.tsx
@@ -48,11 +48,11 @@ export const FormYou = () => {
         {isDisasterCalculation && <HousingDamage />}
         {isDisasterCalculation && <HousingReconstruction />}
         {isDisasterCalculation && <HouseholdGoodsDamage />}
-        {isDisasterCalculation && <DisasterDeath />}
         {isDisasterCalculation && (
           <DisasterInjuryPeriod personName={yourName} />
         )}
         {isDisasterCalculation && <DisasterDisability personName={yourName} />}
+        {isDisasterCalculation && <DisasterDeath />}
 
         {isDetailedCalculation && <Deposit personName={yourName} />}
         {isDetailedCalculation && <Student personName={yourName} />}

--- a/dashboard/src/components/forms/you.tsx
+++ b/dashboard/src/components/forms/you.tsx
@@ -17,6 +17,8 @@ import { NursingHome } from './attributes/NursingHome';
 import { Pregnant } from './attributes/Pregnant';
 import { Deposit } from './attributes/Deposit';
 import { DisasterDeath } from './attributes/DisasterDeath';
+import { DisasterDisability } from './attributes/DisasterDisability';
+import { HouseholdGoodsDamage } from './attributes/HouseholdGoodsDamage';
 
 export const FormYou = () => {
   const location = useLocation();
@@ -39,7 +41,10 @@ export const FormYou = () => {
           <Birthday personName={yourName} mustInput={true} />
         )}
         <Income personName={yourName} mustInput={true} />
+
         {isDisasterCalculation && <DisasterDeath />}
+        {isDisasterCalculation && <HouseholdGoodsDamage />}
+
         {isDetailedCalculation && <Deposit personName={yourName} />}
         {isDetailedCalculation && <Student personName={yourName} />}
         {isDetailedCalculation && <Working personName={yourName} />}
@@ -48,9 +53,11 @@ export const FormYou = () => {
         {isDetailedCalculation && <NursingHome personName={yourName} />}
         <SpouseExists />
         <ChildrenNum />
-        {isDetailedCalculation && <ParentsNum />}
+        {(isDetailedCalculation || isDisasterCalculation) && <ParentsNum />}
         {isDetailedCalculation && <Pregnant personName={yourName} />}
         {isDetailedCalculation && <RentingHouse />}
+
+        {isDisasterCalculation && <DisasterDisability personName={yourName} />}
       </Box>
     </>
   );

--- a/dashboard/src/components/forms/you.tsx
+++ b/dashboard/src/components/forms/you.tsx
@@ -19,6 +19,9 @@ import { Deposit } from './attributes/Deposit';
 import { DisasterDeath } from './attributes/DisasterDeath';
 import { DisasterDisability } from './attributes/DisasterDisability';
 import { HouseholdGoodsDamage } from './attributes/HouseholdGoodsDamage';
+import { HousingDamage } from './attributes/HousingDamage';
+import { HousingReconstruction } from './attributes/HousingReconstruction';
+import { DisasterInjuryPeriod } from './attributes/DisasterInjuryPeriod';
 
 export const FormYou = () => {
   const location = useLocation();
@@ -42,8 +45,14 @@ export const FormYou = () => {
         )}
         <Income personName={yourName} mustInput={true} />
 
-        {isDisasterCalculation && <DisasterDeath />}
+        {isDisasterCalculation && <HousingDamage />}
+        {isDisasterCalculation && <HousingReconstruction />}
         {isDisasterCalculation && <HouseholdGoodsDamage />}
+        {isDisasterCalculation && <DisasterDeath />}
+        {isDisasterCalculation && (
+          <DisasterInjuryPeriod personName={yourName} />
+        )}
+        {isDisasterCalculation && <DisasterDisability personName={yourName} />}
 
         {isDetailedCalculation && <Deposit personName={yourName} />}
         {isDetailedCalculation && <Student personName={yourName} />}
@@ -56,8 +65,6 @@ export const FormYou = () => {
         {(isDetailedCalculation || isDisasterCalculation) && <ParentsNum />}
         {isDetailedCalculation && <Pregnant personName={yourName} />}
         {isDetailedCalculation && <RentingHouse />}
-
-        {isDisasterCalculation && <DisasterDisability personName={yourName} />}
       </Box>
     </>
   );

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -8,7 +8,7 @@ import { useCalculate } from '../../hooks/calculate';
 import { Benefit } from './benefit';
 import { Loan } from './loan';
 import { CalculationLabel } from '../forms/calculationLabel';
-import { currentDateAtom, householdAtom } from '../../state';
+import { householdAtom } from '../../state';
 import { useRecoilValue } from 'recoil';
 
 const createFileName = (extension: string = '', ...names: string[]) => {
@@ -29,7 +29,6 @@ export const Result = () => {
 
   const navigate = useNavigate();
 
-  const currentDate = useRecoilValue(currentDateAtom);
   const household = useRecoilValue(householdAtom);
   const [result, calculate] = useCalculate();
   const [isDisplayChat, setIsDisplayChat] = useState('none');

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -175,6 +175,25 @@
             "教材費、通学用品費等、高校で安心して教育を受けるために必要なお金の給付"
           ],
           "reference": "https://www.mext.go.jp/a_menu/shotou/mushouka/1344089.htm"
+        },
+        "災害弔慰金": {
+          "unit": "円 　",
+          "caption": ["災害により亡くなられた方のご遺族に支給されるお金"],
+          "reference": "https://www.mhlw.go.jp/shinsai_jouhou/saigaishien.html"
+        },
+        "災害障害見舞金": {
+          "unit": "円 　",
+          "caption": [
+            "災害による負傷・疾病で精神又は身体に著しい障害が出た方に支給されるお金"
+          ],
+          "reference": "https://www.mhlw.go.jp/shinsai_jouhou/saigaishien.html"
+        },
+        "被災者生活再建支援制度": {
+          "unit": "円 　",
+          "caption": [
+            "災害により居住する住宅が全壊するなど、生活基盤に著しい被害を受けた世帯に対する支援金"
+          ],
+          "reference": "https://tkai.jp/reconstruction/tabid/82/Default.aspx"
         }
       }
     },
@@ -279,6 +298,15 @@
             ],
             "reference": "https://jukenchallenge.jp",
             "local": "東京都"
+          },
+          "災害援護資金": {
+            "unit": "円 　",
+            "caption": [
+              "生活の再建に必要な資金",
+              "返済期限：10年以内",
+              "利子：年3%以内"
+            ],
+            "reference": "https://www.mhlw.go.jp/shinsai_jouhou/saigaishien.html"
           }
         }
       }

--- a/dashboard/src/state.ts
+++ b/dashboard/src/state.ts
@@ -96,6 +96,26 @@ export const householdAtom = atom<any>({
         受験生チャレンジ支援貸付: {
           [currentDate]: null,
         },
+        // Disaster condolence money
+        災害弔慰金: {
+          [currentDate]: null,
+        },
+        // Disaster disability compensation money MAX
+        災害障害見舞金_最大: {
+          [currentDate]: null,
+        },
+        // Disaster disability compensation money MIN
+        災害障害見舞金_最小: {
+          [currentDate]: null,
+        },
+        // Disaster victim life reconstruction support system
+        被災者生活再建支援制度: {
+          [currentDate]: null,
+        },
+        // Disaster relief funds
+        災害援護資金: {
+          [currentDate]: null,
+        },
       },
     },
   },


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は 被災者支援制度用フォームを追加する
  - そのために 入力項目 を追加した
    - 住宅被害・再建方法
    - 家財の損害
    - 災害による負傷の療養期間
    - 災害による障害
    - 災害による世帯員の死亡
  - そのために 既存入力項目のラベル を被災者フォーム用に変更した
    - 「被災前の」年収
    - 「存命の」世帯員
  - 見積もり対象制度の追加
    - 災害弔慰金
    - 災害障害見舞金
    - 被災者生活再建支援制度
    - 災害援護資金

## 動作確認

- [x] 追加|変更した部分の影響しそうな箇所をテスト|目視確認した
