### PR TITLE
/result へのアクセスのエラー対策

### DIFF
--- a/dashboard/src/components/errors/FormResponseError.tsx
+++ b/dashboard/src/components/errors/FormResponseError.tsx
@@ -4,10 +4,12 @@ import configData from '../../config/app_config.json';
 
 export const FormResponseError = () => {
   const location = useLocation();
-  const { isSimpleCalculation, isDisasterCalculation } = location.state as {
-    isSimpleCalculation: boolean;
-    isDisasterCalculation: boolean;
-  };
+  const { isSimpleCalculation, isDisasterCalculation, redirect } =
+    location.state as {
+      isSimpleCalculation: boolean;
+      isDisasterCalculation: boolean;
+      redirect: string;
+    };
 
   return (
     <Box bg="white" borderRadius="xl" p={4} mt={4} mb={4} ml={4} mr={4}>
@@ -33,7 +35,7 @@ export const FormResponseError = () => {
               ? '/calculate-simple'
               : isDisasterCalculation
               ? '/calculate-disaster'
-              : '/calculate'
+              : redirect ?? '/calculate'
           }
         >
           戻る

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -58,7 +58,8 @@ export const Result = () => {
 
   useEffect(() => {
     const key = getShareKey();
-    if (!household.世帯員.あなた.収入 && key) {
+    const required = resuiredHousehold(household);
+    if (!required && key) {
       try {
         // URLパラメータから受け取った圧縮されたデータを展開
         setShareUrl(getShareLink(key));
@@ -156,6 +157,22 @@ export const Result = () => {
       .catch((e: any) => {
         console.error('Failed to copy text:', e);
       });
+  };
+
+  const resuiredHousehold = (household: any) => {
+    if (typeof household !== 'object') {
+      return false;
+    }
+
+    if (
+      !household.世帯員.あなた.収入 ||
+      !household.世帯一覧.世帯1.居住市区町村 ||
+      !household.世帯一覧.世帯1.居住都道府県
+    ) {
+      return false;
+    }
+
+    return true;
   };
 
   return (

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -46,6 +46,7 @@ export const Result = () => {
       state: {
         isSimpleCalculation: isSimpleCalculation,
         isDisasterCalculation: isDisasterCalculation,
+        redirect: '/',
       },
     });
   };

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -41,6 +41,15 @@ export const Result = () => {
 
   const navigate = useNavigate();
 
+  const errorRedirect = () => {
+    navigate('/response-error', {
+      state: {
+        isSimpleCalculation: isSimpleCalculation,
+        isDisasterCalculation: isDisasterCalculation,
+      },
+    });
+  };
+
   let household = useRecoilValue(householdAtom);
   const [result, calculate] = useCalculate();
   const [isDisplayChat, setIsDisplayChat] = useState('none');
@@ -56,6 +65,7 @@ export const Result = () => {
         household = JSON.parse(inflate(key));
       } catch (error) {
         console.error('Failed to inflate shared data:', error);
+        errorRedirect();
       }
     }
   }, []);
@@ -67,12 +77,7 @@ export const Result = () => {
         console.log(e);
 
         // 想定外のエラーレスポンスを受け取り結果が取得できなかった場合、エラー画面へ遷移
-        navigate('/response-error', {
-          state: {
-            isSimpleCalculation: isSimpleCalculation,
-            isDisasterCalculation: isDisasterCalculation,
-          },
-        });
+        errorRedirect();
       });
       calcOnce = false;
     }

--- a/dashboard/src/hooks/calculate.ts
+++ b/dashboard/src/hooks/calculate.ts
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import configData from '../config/app_config.json';
 import { useRecoilState } from 'recoil';
 import { householdAtom } from './../state';


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は #252 を修正する
  - そのために [`result.tsx`](https://github.com/project-inclusive/OpenFisca-Japan/compare/develop...minagishl:OpenFisca-Japan:develop?expand=1#diff-e4b873424f2d7aaa13a83832a810bdc18a75ed4765d02da8e8bf496c9688621d) を修正した
  
 説明
 
 1. `/result` への直アクセスは `response-error` へリダイレクトする
 2. `/result` への `calculate`, `calculate-simple` などからのアクセスは結果を表示
 3. `/result?share={key}` でのアクセスはキーをJSONに変換し正しい場合は結果を表示し、
正しくない場合は `response-error` へリダイレクトされます

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
