### PR TITLE
子どもが20歳以上の場合でも入力できるよう修正

### DIFF
--- a/dashboard/src/components/forms/attributes/SchoolYear.tsx
+++ b/dashboard/src/components/forms/attributes/SchoolYear.tsx
@@ -158,8 +158,7 @@ export const SchoolYear = ({
       // 20歳以降は変化がないのでフィルタリング
       if (
         totalSchoolYear >= info.minTotalSchoolYear &&
-        totalSchoolYear <= info.maxTotalSchoolYear &&
-        age < 20
+        totalSchoolYear <= info.maxTotalSchoolYear
       ) {
         setschoolEducationalAuthority(info.building);
         setSchoolYear(totalSchoolYear - info.diff + 6);


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は フロントエンドの子どもの年齢欄 を修正する
  - そのために 学年との同期ロジック を変更した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した

![image](https://github.com/project-inclusive/OpenFisca-Japan/assets/36665200/7d8f3fda-9570-4c4c-b091-32254d4a3533)

（参考：developでは20歳を選択すると「小学校入学前」になり、「高校卒業後相当」に直そうとすると年齢が3歳になってしまっていた）

![image](https://github.com/project-inclusive/OpenFisca-Japan/assets/36665200/501c9bdb-fcb7-4f54-a86a-0cfe39c42223)

![image](https://github.com/project-inclusive/OpenFisca-Japan/assets/36665200/98ccb9b9-1538-4a62-9c94-c9db4bcf3b7b)


