### PR TITLE
ブラウザバックしてから再見積もりした際に変更した世帯情報が反映されない問題を解決する

### DIFF
--- a/dashboard/src/components/forms/attributes/AgeInput.tsx
+++ b/dashboard/src/components/forms/attributes/AgeInput.tsx
@@ -39,7 +39,7 @@ export const AgeInput = ({
         ETERNITY: `${birthYear.toString()}-01-01`,
       };
       setHousehold(newHousehold);
-      console.log('[DEBUG] household -> ', newHousehold);
+      //console.log('[DEBUG] household -> ', newHousehold);
     }
   };
 

--- a/dashboard/src/components/result/helpDesk.tsx
+++ b/dashboard/src/components/result/helpDesk.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { Box, Link, Text } from '@chakra-ui/react';
 import { ExternalLinkIcon } from '@chakra-ui/icons';
 
@@ -8,10 +9,13 @@ import { useRecoilValue } from 'recoil';
 export const HelpDesk = () => {
   const currentDate = useRecoilValue(currentDateAtom);
   const household = useRecoilValue(householdAtom);
+  const [prefecture, setPrefecture] = useState('');
+  const [city, setCity] = useState('');
 
-  const prefecture = household.世帯一覧.世帯1.居住都道府県[currentDate];
-
-  const city = household.世帯一覧.世帯1.居住市区町村[currentDate];
+  useEffect(() => {
+    setPrefecture(household.世帯一覧.世帯1.居住都道府県[currentDate]);
+    setCity(household.世帯一覧.世帯1.居住市区町村[currentDate]);
+  }, [household]);
 
   const getSocialWelfareCouncilData = () => {
     if (

--- a/dashboard/src/components/result/shareLink.ts
+++ b/dashboard/src/components/result/shareLink.ts
@@ -41,7 +41,7 @@ export default function shortLink(
   isDisasterCalculation: boolean
 ): string {
   const key = deflate(JSON.stringify(obj));
-  console.log('[DEBUG] shortLink -> key: ', key);
+  //console.log('[DEBUG] shortLink -> key: ', key);
   return `${window.location.protocol}//${
     window.location.host
   }/result?share=${key}&1=${isSimpleCalculation ? 1 : 0}&2=${
@@ -68,7 +68,7 @@ export function getShareLink(key?: string): string {
 export function getShareKey(): string {
   const urlParams = new URLSearchParams(window.location.search);
   const key = String(urlParams.get('share')).replaceAll(' ', '+');
-  console.log('[DEBUG] getShareKey -> key: ', key);
+  //console.log('[DEBUG] getShareKey -> key: ', key);
   return key;
 }
 

--- a/dashboard/src/hooks/calculate.ts
+++ b/dashboard/src/hooks/calculate.ts
@@ -1,9 +1,11 @@
 import configData from '../config/app_config.json';
-import { useRecoilState } from 'recoil';
-import { householdAtom } from './../state';
+import { useState } from 'react';
 
 export const useCalculate = () => {
-  const [result, setResult] = useRecoilState(householdAtom);
+  // recoilのhouseholdには結果を格納する制度の金額にnullでない数値が入力され、
+  // そのobjectをブラウザバックして再POSTするとOpenFiscaで計算されない。
+  // そのため結果はhouseholdに格納せず、localのstateとして管理する。
+  const [result, setResult] = useState<any>();
   const apiURL =
     import.meta.env.VITE_BRANCH === 'production'
       ? configData.URL.OpenFisca_API.production // mainブランチマージ時にビルドされるバックエンドAPI。Cloud Run


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は ブラウザバックしてから再見積もりした際に変更した世帯情報が反映されない問題を解決する
  - そのために 算出結果のjsonをhouseholdにセットしないようにした
  
 #261 でresult objectをrecoilのhousehold に保存するようにしていますが、そうすると制度の金額にnullでない数値が入力され、そのobjectをブラウザバックして再POSTするとOpenFiscaで計算されません。
そのため結果はhouseholdに格納せず、localのstateとして管理するように戻します。

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
