### PR TITLE
フォームの数字入力上限を設定

### DIFF
--- a/dashboard/src/components/forms/attributes/AgeInput.tsx
+++ b/dashboard/src/components/forms/attributes/AgeInput.tsx
@@ -52,7 +52,7 @@ export const AgeInput = ({
     }
 
     const numValue = Number(value);
-    const inputAge = numValue < 0 ? '' : numValue;
+    const inputAge = numValue < 0 || numValue > 200 ? '' : numValue; // 0~200歳に入力を制限(年齢が高すぎて誕生年が3桁になるとパース処理が煩雑なため)
     changeAge(Number(inputAge));
   };
 

--- a/dashboard/src/components/forms/attributes/Deposit.tsx
+++ b/dashboard/src/components/forms/attributes/Deposit.tsx
@@ -27,11 +27,15 @@ export const Deposit = ({ personName }: { personName: string }) => {
 
     // 「万円」単位を「円」に換算
     let deposit = parseInt(value) * 10000;
+    const maxDeposit = 10000000000; // オーバーフローしないよう上限を100億に設定
 
     // 正の整数以外は0に変換
     if (isNaN(deposit) || deposit < 0) {
       deposit = 0;
       setShownDeposit('');
+    } else if (deposit > maxDeposit) {
+      deposit = maxDeposit;
+      setShownDeposit(deposit / 10000);
     } else {
       setShownDeposit(deposit / 10000);
     }

--- a/dashboard/src/components/forms/attributes/Income.tsx
+++ b/dashboard/src/components/forms/attributes/Income.tsx
@@ -31,6 +31,7 @@ export const Income = ({
     // 全角数字を半角数字に変換
     let value = toHalf(event.target.value);
     value = value.replace(/[^0-9]/g, '');
+    const maxIncome = 10000000000; // オーバーフローしないよう上限を100億に設定
 
     // 「万円」単位を「円」に換算
     let income = parseInt(value) * 10000;
@@ -38,6 +39,9 @@ export const Income = ({
     if (isNaN(income) || income < 0) {
       income = 0;
       setShownIncome('');
+    } else if (income > maxIncome) {
+      income = maxIncome;
+      setShownIncome(income / 10000);
     } else {
       setShownIncome(income / 10000);
     }


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は フォームに大きな数字を入力した時にエラーが起きないよう修正する。
  - そのために 「年齢」・「年収」・「預貯金」フォームに入力可能な数字の上限 を設定した
  - 修正前は「年齢」が高すぎて誕生年が西暦3桁になると、後段でパースエラーが発生してNaNとなり、フォーム上の数字表現が異常になっていた。
    - そのため、影響範囲・修正範囲が少なくなるよう、入力する前段で上限を設けることとした。
    - Issue #355 関連の修正です。半角・全角でも修正前は同様の挙動が見られました。ただ、#355 が本PRだけの問題かは不明です。

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
  -  「年齢」を201歳以上にしたときに0歳に、「年収」・「預貯金」の入力上限が100億になることを確認。
  
<img width="237" alt="スクリーンショット 2025-01-11 11 24 19" src="https://github.com/user-attachments/assets/30c55e4a-da61-4418-b103-88e344cb997d" />

  - 上記でフォームの値が上限以下に変更されたときに、その値でバックエンドにPOSTされていることを確認。
<img width="451" alt="スクリーンショット 2025-01-11 11 25 08" src="https://github.com/user-attachments/assets/5877fab3-a382-49b9-ad1e-3df57121b659" />
