### PR TITLE
assetのファイルを読み込むときの絶対パスを指定（シミュレーション対応）

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -25,7 +25,7 @@ jobs:
         run: make build
       - name: Cache release
         id: restore-release
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: dist
           key: release-${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ github.sha }}

--- a/docs/about_openfisca.md
+++ b/docs/about_openfisca.md
@@ -278,7 +278,7 @@ return 居住地条件 * 金額
 # csvファイル読み込み
 @cache
 def 支給限度額_学年制表():
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校等就学支援金/支給額/支給限度額_学年制.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校等就学支援金/支給額/支給限度額_学年制.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:] # ヘッダーを読み込まないようインデックスは1始まり
 ```
 

--- a/openfisca_japan/variables/住居.py
+++ b/openfisca_japan/variables/住居.py
@@ -14,9 +14,8 @@ import numpy as np
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
 # Import the Entities specifically defined for this tax and benefit system
-from openfisca_japan.entities import 世帯
-
 from openfisca_japan import COUNTRY_DIR
+from openfisca_japan.entities import 世帯
 
 
 @cache

--- a/openfisca_japan/variables/住居.py
+++ b/openfisca_japan/variables/住居.py
@@ -16,6 +16,8 @@ from openfisca_core.variables import Variable
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_japan.entities import 世帯
 
+from openfisca_japan import COUNTRY_DIR
+
 
 @cache
 def 市区町村級地区分_キー一覧():
@@ -24,7 +26,7 @@ def 市区町村級地区分_キー一覧():
 
     各要素は [都道府県名, 市区町村名] の形式
     """
-    with open("openfisca_japan/assets/市区町村級地区分.json") as f:
+    with open(COUNTRY_DIR + "/assets/市区町村級地区分.json") as f:
         d = json.load(f)
         キー一覧 = []
         for 都道府県名, 都道府県データ in d.items():
@@ -40,7 +42,7 @@ def 市区町村級地区分_値一覧():
 
     市区町村級地区分_値一覧[市区町村級地区分キー, 区分]の形式で取得可能
     """
-    with open("openfisca_japan/assets/市区町村級地区分.json") as f:
+    with open(COUNTRY_DIR + "/assets/市区町村級地区分.json") as f:
         d = json.load(f)
         値一覧 = []
         for 都道府県データ in d.values():

--- a/openfisca_japan/variables/住民税.py
+++ b/openfisca_japan/variables/住民税.py
@@ -11,6 +11,8 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY, period
 from openfisca_core.variables import Variable
+
+from openfisca_japan import COUNTRY_DIR
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_japan.entities import 世帯, 人物
 from openfisca_japan.variables.全般 import 性別パターン
@@ -25,7 +27,7 @@ def 配偶者控除額表():
 
     配偶者控除額表()[配偶者の所得区分, 納税者本人の所得区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/住民税/配偶者控除額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/住民税/配偶者控除額.csv",
                   delimiter=",", skip_header=1, dtype="int64")[np.newaxis, 1:]
 
 
@@ -36,7 +38,7 @@ def 老人控除対象配偶者_配偶者控除額表():
 
     老人控除対象配偶者_配偶者控除額表()[配偶者の所得区分, 納税者本人の所得区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/住民税/配偶者控除額_老人控除対象配偶者.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/住民税/配偶者控除額_老人控除対象配偶者.csv",
                          delimiter=",", skip_header=1, dtype="int64")[np.newaxis, 1:]
 
 
@@ -47,7 +49,7 @@ def 配偶者特別控除額表():
 
     配偶者特別控除額表()[配偶者の所得区分, 納税者本人の所得区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/住民税/配偶者特別控除額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/住民税/配偶者特別控除額.csv",
                   delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 

--- a/openfisca_japan/variables/住民税.py
+++ b/openfisca_japan/variables/住民税.py
@@ -11,7 +11,6 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY, period
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_japan.entities import 世帯, 人物

--- a/openfisca_japan/variables/所得税.py
+++ b/openfisca_japan/variables/所得税.py
@@ -13,7 +13,6 @@ import numpy as np
 from openfisca_core.holders import set_input_divide_by_period
 from openfisca_core.periods import DAY, period
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_japan.entities import 世帯, 人物

--- a/openfisca_japan/variables/所得税.py
+++ b/openfisca_japan/variables/所得税.py
@@ -13,6 +13,8 @@ import numpy as np
 from openfisca_core.holders import set_input_divide_by_period
 from openfisca_core.periods import DAY, period
 from openfisca_core.variables import Variable
+
+from openfisca_japan import COUNTRY_DIR
 # Import the Entities specifically defined for this tax and benefit system
 from openfisca_japan.entities import 世帯, 人物
 from openfisca_japan.variables.障害.愛の手帳 import 愛の手帳等級パターン
@@ -31,7 +33,7 @@ def 配偶者控除額表():
 
     配偶者控除額表()[配偶者の所得区分, 納税者本人の所得区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/所得/配偶者控除額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/所得/配偶者控除額.csv",
                   delimiter=",", skip_header=1, dtype="int64")[np.newaxis, 1:]
 
 
@@ -42,7 +44,7 @@ def 配偶者特別控除額表():
 
     配偶者特別控除額表()[配偶者の所得区分, 納税者本人の所得区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/所得/配偶者特別控除額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/所得/配偶者特別控除額.csv",
                   delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -53,7 +55,7 @@ def 老人控除対象配偶者_配偶者控除額表():
 
     老人控除対象配偶者_配偶者控除額表()[配偶者の所得区分, 納税者本人の所得区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/所得/配偶者控除額_老人控除対象配偶者.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/所得/配偶者控除額_老人控除対象配偶者.csv",
                          delimiter=",", skip_header=1, dtype="int64")[np.newaxis, 1:]
 
 

--- a/openfisca_japan/variables/災害/支援/災害援護資金.py
+++ b/openfisca_japan/variables/災害/支援/災害援護資金.py
@@ -7,6 +7,8 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
+
+from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯
 from openfisca_japan.variables.災害.住宅 import 住宅被害パターン, 家財の損害パターン, 災害による負傷の療養期間パターン
 
@@ -18,7 +20,7 @@ def 災害援護資金貸付限度額():
 
     災害援護資金貸付限度額()[災害による負傷の療養期間, 住宅への損害] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/災害/支援/災害援護資金貸付限度額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/災害/支援/災害援護資金貸付限度額.csv",
                   delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 

--- a/openfisca_japan/variables/災害/支援/災害援護資金.py
+++ b/openfisca_japan/variables/災害/支援/災害援護資金.py
@@ -7,7 +7,6 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯
 from openfisca_japan.variables.災害.住宅 import 住宅被害パターン, 家財の損害パターン, 災害による負傷の療養期間パターン

--- a/openfisca_japan/variables/災害/支援/被災者生活再建支援制度.py
+++ b/openfisca_japan/variables/災害/支援/被災者生活再建支援制度.py
@@ -8,6 +8,8 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
+
+from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯
 from openfisca_japan.variables.災害.住宅 import 住宅再建方法パターン, 住宅被害パターン
 
@@ -19,7 +21,7 @@ def 基礎支援金額表():
 
     基礎支援金額表()[住宅被害] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/災害/支援/被災者生活再建支援制度_基礎支援金.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/災害/支援/被災者生活再建支援制度_基礎支援金.csv",
                   delimiter=",", skip_header=1, dtype="int64")[1:]
 
 
@@ -30,7 +32,7 @@ def 加算支援金額表():
 
     加算支援金額表()[住宅被害, 住宅再建方法] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/災害/支援/被災者生活再建支援制度_加算支援金.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/災害/支援/被災者生活再建支援制度_加算支援金.csv",
                   delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 

--- a/openfisca_japan/variables/災害/支援/被災者生活再建支援制度.py
+++ b/openfisca_japan/variables/災害/支援/被災者生活再建支援制度.py
@@ -8,7 +8,6 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯
 from openfisca_japan.variables.災害.住宅 import 住宅再建方法パターン, 住宅被害パターン

--- a/openfisca_japan/variables/福祉/生活保護.py
+++ b/openfisca_japan/variables/福祉/生活保護.py
@@ -10,6 +10,8 @@ import numpy as np
 from openfisca_core.indexed_enums import Enum
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
+
+from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯, 人物
 from openfisca_japan.variables.障害.身体障害者手帳 import 身体障害者手帳等級パターン
 
@@ -25,7 +27,7 @@ def 生活扶助基準1_第1類_基準額1表():
 
     生活扶助基準1_第1類_基準額1表()[年齢, 居住級地区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/生活扶助基準額/第1類1.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/生活扶助基準額/第1類1.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -36,7 +38,7 @@ def 生活扶助基準1_逓減率1表():
 
     生活扶助基準1_逓減率1表()[世帯人数, 居住級地区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/生活扶助基準額/逓減率1.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/生活扶助基準額/逓減率1.csv",
                          delimiter=",", skip_header=1, dtype="float64")[:, 1:]
 
 
@@ -47,7 +49,7 @@ def 生活扶助基準1_第2類_基準額1表():
 
     生活扶助基準1_第2類_基準額1表()[世帯人数, 居住級地区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/生活扶助基準額/第2類1.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/生活扶助基準額/第2類1.csv",
                         delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -58,7 +60,7 @@ def 生活扶助基準2_第1類_基準額2表():
 
     生活扶助基準2_第1類_基準額2表()[年齢, 居住級地区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/生活扶助基準額/第1類2.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/生活扶助基準額/第1類2.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -69,7 +71,7 @@ def 生活扶助基準2_逓減率2表():
 
     生活扶助基準2_逓減率2表()[世帯人数, 居住級地区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/生活扶助基準額/逓減率2.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/生活扶助基準額/逓減率2.csv",
                          delimiter=",", skip_header=1, dtype="float64")[:, 1:]
 
 
@@ -80,7 +82,7 @@ def 生活扶助基準2_第2類_基準額2表():
 
     生活扶助基準2_第2類_基準額2表()[世帯人数, 居住級地区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/生活扶助基準額/第2類2.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/生活扶助基準額/第2類2.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -92,7 +94,7 @@ def 地域区分表():
     地域区分表()[都道府県] の形で参照可能
     票に含まれていないものはすべて6区
     """
-    with open("openfisca_japan/assets/福祉/生活保護/冬季加算/地域区分.json") as f:
+    with open(COUNTRY_DIR + "/assets/福祉/生活保護/冬季加算/地域区分.json") as f:
         d = json.load(f)
         return np.array(list(d.values()))
 
@@ -104,7 +106,7 @@ def 地域区分表_キー一覧():
 
     selectする際のキー一覧として都道府県名を取得
     """
-    with open("openfisca_japan/assets/福祉/生活保護/冬季加算/地域区分.json") as f:
+    with open(COUNTRY_DIR + "/assets/福祉/生活保護/冬季加算/地域区分.json") as f:
         d = json.load(f)
         return d.keys()
 
@@ -118,7 +120,7 @@ def 冬季加算表():
     """
     冬季加算表 = []
     for i in range(1, 7):
-        地域区分の冬季加算表 = np.genfromtxt(f"openfisca_japan/assets/福祉/生活保護/冬季加算/{i}区.csv",
+        地域区分の冬季加算表 = np.genfromtxt(COUNTRY_DIR + f"/assets/福祉/生活保護/冬季加算/{i}区.csv",
                                    delimiter=",", skip_header=1, dtype="int64")[:, 1:]
         冬季加算表.append(地域区分の冬季加算表)
     return np.stack(冬季加算表)
@@ -131,7 +133,7 @@ def 市ごとの住宅扶助限度額():
 
     市ごとの住宅扶助限度額()[市, 世帯人員] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/住宅扶助基準額/市.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/住宅扶助基準額/市.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -142,7 +144,7 @@ def 市ごとの住宅扶助限度額_キー一覧():
 
     selectする際のキー一覧として市名を取得
     """
-    with open("openfisca_japan/assets/福祉/生活保護/住宅扶助基準額/市.csv") as f:
+    with open(COUNTRY_DIR + "/assets/福祉/生活保護/住宅扶助基準額/市.csv") as f:
         reader = csv.DictReader(f)
         return [row["市"] for row in reader]
 
@@ -154,7 +156,7 @@ def 都道府県ごとの住宅扶助限度額():
 
     都道府県ごとの住宅扶助限度額()[都道府県区分, 世帯人員] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/住宅扶助基準額/都道府県.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/住宅扶助基準額/都道府県.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 2:]
 
 
@@ -165,7 +167,7 @@ def 都道府県ごとの住宅扶助限度額_キー一覧():
 
     selectする際のキー一覧として都道府県名、級地区分を取得
     """
-    with open("openfisca_japan/assets/福祉/生活保護/住宅扶助基準額/都道府県.csv") as f:
+    with open(COUNTRY_DIR + "/assets/福祉/生活保護/住宅扶助基準額/都道府県.csv") as f:
         reader = csv.DictReader(f)
         return [{"都道府県": row["都道府県"], "級地": int(row["級地"])} for row in reader]
 
@@ -179,7 +181,7 @@ def 生活扶助本体に係る経過的加算表():
     """
     生活扶助本体に係る経過的加算表 = []
     for i in range(1, 6):
-        生活扶助本体に係る経過的加算表.append(np.genfromtxt(f"openfisca_japan/assets/福祉/生活保護/生活扶助本体に係る経過的加算/{i}人世帯.csv",
+        生活扶助本体に係る経過的加算表.append(np.genfromtxt(COUNTRY_DIR + f"/assets/福祉/生活保護/生活扶助本体に係る経過的加算/{i}人世帯.csv",
                                          delimiter=",", skip_header=1, dtype="int64")[:, 1:])
     return np.stack(生活扶助本体に係る経過的加算表)
 
@@ -193,11 +195,11 @@ def 母子世帯等に係る経過的加算表():
     """
     母子世帯等に係る経過的加算表 = []
 
-    母子世帯等に係る経過的加算表.append(np.genfromtxt("openfisca_japan/assets/福祉/生活保護/母子世帯等に係る経過的加算/3人世帯.csv",
+    母子世帯等に係る経過的加算表.append(np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/母子世帯等に係る経過的加算/3人世帯.csv",
                                      delimiter=",", skip_header=1, dtype="int64")[:, 1:])
-    母子世帯等に係る経過的加算表.append(np.genfromtxt("openfisca_japan/assets/福祉/生活保護/母子世帯等に係る経過的加算/4人世帯.csv",
+    母子世帯等に係る経過的加算表.append(np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/母子世帯等に係る経過的加算/4人世帯.csv",
                                      delimiter=",", skip_header=1, dtype="int64")[:, 1:])
-    母子世帯等に係る経過的加算表.append(np.genfromtxt("openfisca_japan/assets/福祉/生活保護/母子世帯等に係る経過的加算/5人世帯.csv",
+    母子世帯等に係る経過的加算表.append(np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/母子世帯等に係る経過的加算/5人世帯.csv",
                                      delimiter=",", skip_header=1, dtype="int64")[:, 1:])
 
     return np.stack(母子世帯等に係る経過的加算表)
@@ -210,7 +212,7 @@ def 障害者加算表():
 
     障害者加算表()[等級, 居住級地区分1] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/障害者加算.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/障害者加算.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -221,7 +223,7 @@ def 期末一時扶助表():
 
     期末一時扶助表()[世帯人数, 居住級地区分] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/生活保護/期末一時扶助.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/生活保護/期末一時扶助.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 

--- a/openfisca_japan/variables/福祉/生活保護.py
+++ b/openfisca_japan/variables/福祉/生活保護.py
@@ -10,7 +10,6 @@ import numpy as np
 from openfisca_core.indexed_enums import Enum
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯, 人物
 from openfisca_japan.variables.障害.身体障害者手帳 import 身体障害者手帳等級パターン

--- a/openfisca_japan/variables/福祉/育児/高等学校奨学給付金.py
+++ b/openfisca_japan/variables/福祉/育児/高等学校奨学給付金.py
@@ -8,7 +8,6 @@ import numpy as np
 from openfisca_core.indexed_enums import Enum
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯, 人物
 from openfisca_japan.variables.全般 import 高校生学年

--- a/openfisca_japan/variables/福祉/育児/高等学校奨学給付金.py
+++ b/openfisca_japan/variables/福祉/育児/高等学校奨学給付金.py
@@ -8,6 +8,8 @@ import numpy as np
 from openfisca_core.indexed_enums import Enum
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
+
+from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯, 人物
 from openfisca_japan.variables.全般 import 高校生学年
 
@@ -19,7 +21,7 @@ def 国立高等学校奨学給付金表():
 
     国立高等学校奨学給付金表()[世帯区分, 履修形態] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校奨学給付金/国立高等学校奨学給付金額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校奨学給付金/国立高等学校奨学給付金額.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -30,7 +32,7 @@ def 公立高等学校奨学給付金表():
 
     公立高等学校奨学給付金表()[世帯区分, 履修形態] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校奨学給付金/公立高等学校奨学給付金額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校奨学給付金/公立高等学校奨学給付金額.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -41,7 +43,7 @@ def 私立高等学校奨学給付金表():
 
     私立高等学校奨学給付金表()[世帯区分, 履修形態] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校奨学給付金/私立高等学校奨学給付金額.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校奨学給付金/私立高等学校奨学給付金額.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 

--- a/openfisca_japan/variables/福祉/育児/高等学校等就学支援金.py
+++ b/openfisca_japan/variables/福祉/育児/高等学校等就学支援金.py
@@ -7,6 +7,8 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
+
+from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯
 from openfisca_japan.variables.全般 import 高校生学年
 from openfisca_japan.variables.福祉.育児.高等学校奨学給付金 import 高校履修種別パターン, 高校運営種別パターン
@@ -25,7 +27,7 @@ def 支給限度額_学年制表():
     """
     # NOTE: 特別支援学校等、一部の高校履修種別は非対応（網羅すると判別のために利用者の入力負担が増えてしまうため）
     # https://www.mext.go.jp/a_menu/shotou/mushouka/__icsFiles/afieldfile/2020/04/30/100014428_4.pdf
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校等就学支援金/支給額/支給限度額_学年制.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校等就学支援金/支給額/支給限度額_学年制.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -38,7 +40,7 @@ def 支給限度額_単位制表():
     """
     # 月額の最大値として、年間取得可能最大単位数を取った場合の年額を12か月で按分した値を使用
     # https://www.mext.go.jp/a_menu/shotou/mushouka/__icsFiles/afieldfile/2020/04/30/100014428_4.pdf
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校等就学支援金/支給額/支給限度額_単位制.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校等就学支援金/支給額/支給限度額_単位制.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -49,7 +51,7 @@ def 加算額_学年制表():
 
     加算額_学年制表()[高校履修種別, 高校運営種別] の形で参照可能
     """
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校等就学支援金/支給額/加算額_学年制.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校等就学支援金/支給額/加算額_学年制.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 
@@ -62,7 +64,7 @@ def 加算額_単位制表():
     """
     # 月額の最大値として、年間取得可能最大単位数を取った場合の年額を12か月で按分した値を使用
     # https://www.mext.go.jp/a_menu/shotou/mushouka/__icsFiles/afieldfile/2020/04/30/100014428_4.pdf
-    return np.genfromtxt("openfisca_japan/assets/福祉/育児/高等学校等就学支援金/支給額/加算額_単位制.csv",
+    return np.genfromtxt(COUNTRY_DIR + "/assets/福祉/育児/高等学校等就学支援金/支給額/加算額_単位制.csv",
                          delimiter=",", skip_header=1, dtype="int64")[:, 1:]
 
 

--- a/openfisca_japan/variables/福祉/育児/高等学校等就学支援金.py
+++ b/openfisca_japan/variables/福祉/育児/高等学校等就学支援金.py
@@ -7,7 +7,6 @@ from functools import cache
 import numpy as np
 from openfisca_core.periods import DAY
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 from openfisca_japan.entities import 世帯
 from openfisca_japan.variables.全般 import 高校生学年

--- a/tools/dependency_graph/dependency.py
+++ b/tools/dependency_graph/dependency.py
@@ -11,7 +11,6 @@ import re
 
 import graphviz
 from openfisca_core.variables import Variable
-
 from openfisca_japan import COUNTRY_DIR
 
 

--- a/tools/dependency_graph/dependency.py
+++ b/tools/dependency_graph/dependency.py
@@ -12,6 +12,8 @@ import re
 import graphviz
 from openfisca_core.variables import Variable
 
+from openfisca_japan import COUNTRY_DIR
+
 
 # Variable同士の依存関係を解析（継承はせず動的に読み込んでいるためソースコードから推定）
 class DependencyFinder:
@@ -99,7 +101,7 @@ if __name__ == "__main__":
     dependencies = {}
 
     # openfisca_japanのルートディレクトリ
-    root_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "openfisca_japan")
+    root_dir = COUNTRY_DIR
 
     filenames = glob.glob(f"{root_dir}/**/*.py", recursive=True)
     module_paths = [filename.replace(".py", "").replace("/", ".") for filename in filenames]


### PR DESCRIPTION

## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は assetのファイルを読み込むときの絶対パスを指定する
  - そのために `openfisca_japan/__init__.py` で定義されていた 以下の絶対パス`COUNTRY_DIR`を、assetディレクトリの親ディレクトリとして参照するようにした。
  ```
  COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
  ```
  OpenFisca-Franceでも同様の実装あり。
  https://github.com/openfisca/openfisca-france/blob/8084321cdb75c86f0d16a9343fdb0ca07ce7a9bc/openfisca_france/model/prelevements_obligatoires/prelevements_sociaux/contributions_sociales/versement_transport.py#L64
  
  - シミュレーション時にOpenFisca-Japanをpythonパッケージとして読み込む場合は、絶対パスが正しく指定されていないとassetファイルを読み込めないため。（Google Cloud ClourRunでデプロイする場合は、絶対パスの指定がなくてもassetファイルを読み込める。）

## 動作確認

- [x] `make test`で全テスト成功
- [x] シミュレーションコードの実行成功（後のPRでサンプルコードを追加）

## コメント

シミュレーション対応の第一弾です。CloudRunのdevelopブランチのデプロイで今回の絶対パス指定が影響ないことを念の為確認しておきたく、これだけでPRを切っています。
お手隙の際にご確認お願いします🙏
