### PR TITLE
新UI質問: 「療育手帳または愛の手帳を持っている」を実装する

### DIFF
--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -16,6 +16,7 @@ import { SelfPhysicalDisability } from './questions/selfPhysicalDisability';
 import { SpousePhysicalDisability } from './questions/spousePhysicalDisability';
 import { ChildPhysicalDisability } from './questions/childPhysicalDisability';
 import { ParentPhysicalDisability } from './questions/parentPhysicalDisability';
+import { SelfIntellectualDisability } from './questions/selfIntellectualDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -135,7 +136,7 @@ const questions = {
     },
     {
       title: '療育手帳、愛の手帳',
-      component: <DummyQuestion key={28} />,
+      component: <SelfIntellectualDisability key={28} />,
     },
     {
       title: '放射線障害',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -18,6 +18,7 @@ import { ChildPhysicalDisability } from './questions/childPhysicalDisability';
 import { ParentPhysicalDisability } from './questions/parentPhysicalDisability';
 import { SelfIntellectualDisability } from './questions/selfIntellectualDisability';
 import { SpouseIntellectualDisability } from './questions/spouseIntellectualDisability';
+import { ChildIntellectualDisability } from './questions/childIntellectualDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -433,7 +434,7 @@ const questions = {
     },
     {
       title: '療育手帳、愛の手帳',
-      component: <DummyQuestion key={28} />,
+      component: <ChildIntellectualDisability key={28} />,
     },
     {
       title: '放射線障害',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -134,52 +134,48 @@ const questions = {
       component: <DummyQuestion key={27} />,
     },
     {
-      title: '療育手帳',
+      title: '療育手帳、愛の手帳',
       component: <DummyQuestion key={28} />,
     },
     {
-      title: '愛の手帳',
+      title: '放射線障害',
       component: <DummyQuestion key={29} />,
     },
     {
-      title: '放射線障害',
+      title: '内部障害',
       component: <DummyQuestion key={30} />,
     },
     {
-      title: '内部障害',
+      title: '脳性まひ',
       component: <DummyQuestion key={31} />,
     },
     {
-      title: '脳性まひ',
+      title: '介護施設',
       component: <DummyQuestion key={32} />,
     },
     {
-      title: '介護施設',
+      title: '学生かどうか',
       component: <DummyQuestion key={33} />,
     },
     {
-      title: '学生かどうか',
+      title: '家を借りたい',
       component: <DummyQuestion key={34} />,
     },
     {
-      title: '家を借りたい',
+      title: '妊娠',
       component: <DummyQuestion key={35} />,
     },
     {
-      title: '妊娠',
-      component: <DummyQuestion key={36} />,
-    },
-    {
       title: '配偶者の有無',
-      component: <SpouseExistsQuestion key={37} />,
+      component: <SpouseExistsQuestion key={36} />,
     },
     {
       title: '子どもの人数',
-      component: <ChildrenNumQuestion key={38} />,
+      component: <ChildrenNumQuestion key={37} />,
     },
     {
       title: '親の人数',
-      component: <ParentNumQuestion key={39} />,
+      component: <ParentNumQuestion key={38} />,
     },
   ],
   配偶者: [
@@ -292,36 +288,32 @@ const questions = {
       component: <DummyQuestion key={26} />,
     },
     {
-      title: '療育手帳',
+      title: '療育手帳、愛の手帳',
       component: <DummyQuestion key={27} />,
     },
     {
-      title: '愛の手帳',
+      title: '放射線障害',
       component: <DummyQuestion key={28} />,
     },
     {
-      title: '放射線障害',
+      title: '内部障害',
       component: <DummyQuestion key={29} />,
     },
     {
-      title: '内部障害',
+      title: '脳性まひ',
       component: <DummyQuestion key={30} />,
     },
     {
-      title: '脳性まひ',
+      title: '介護施設',
       component: <DummyQuestion key={31} />,
     },
     {
-      title: '介護施設',
+      title: '妊娠',
       component: <DummyQuestion key={32} />,
     },
     {
-      title: '妊娠',
-      component: <DummyQuestion key={33} />,
-    },
-    {
       title: '配偶者がいるがひとり親に該当',
-      component: <DummyQuestion key={34} />,
+      component: <DummyQuestion key={33} />,
     },
   ],
   子ども: [
@@ -438,28 +430,24 @@ const questions = {
       component: <DummyQuestion key={27} />,
     },
     {
-      title: '療育手帳',
+      title: '療育手帳、愛の手帳',
       component: <DummyQuestion key={28} />,
     },
     {
-      title: '愛の手帳',
+      title: '放射線障害',
       component: <DummyQuestion key={29} />,
     },
     {
-      title: '放射線障害',
+      title: '内部障害',
       component: <DummyQuestion key={30} />,
     },
     {
-      title: '内部障害',
+      title: '脳性まひ',
       component: <DummyQuestion key={31} />,
     },
     {
-      title: '脳性まひ',
-      component: <DummyQuestion key={32} />,
-    },
-    {
       title: '介護施設',
-      component: <DummyQuestion key={33} />,
+      component: <DummyQuestion key={32} />,
     },
   ],
   親: [
@@ -572,28 +560,24 @@ const questions = {
       component: <DummyQuestion key={26} />,
     },
     {
-      title: '療育手帳',
+      title: '療育手帳、愛の手帳',
       component: <DummyQuestion key={27} />,
     },
     {
-      title: '愛の手帳',
+      title: '放射線障害',
       component: <DummyQuestion key={28} />,
     },
     {
-      title: '放射線障害',
+      title: '内部障害',
       component: <DummyQuestion key={29} />,
     },
     {
-      title: '内部障害',
+      title: '脳性まひ',
       component: <DummyQuestion key={30} />,
     },
     {
-      title: '脳性まひ',
-      component: <DummyQuestion key={31} />,
-    },
-    {
       title: '介護施設',
-      component: <DummyQuestion key={32} />,
+      component: <DummyQuestion key={31} />,
     },
   ],
 };

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -19,6 +19,7 @@ import { ParentPhysicalDisability } from './questions/parentPhysicalDisability';
 import { SelfIntellectualDisability } from './questions/selfIntellectualDisability';
 import { SpouseIntellectualDisability } from './questions/spouseIntellectualDisability';
 import { ChildIntellectualDisability } from './questions/childIntellectualDisability';
+import { ParentIntellectualDisability } from './questions/parentIntellectualDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -564,7 +565,7 @@ const questions = {
     },
     {
       title: '療育手帳、愛の手帳',
-      component: <DummyQuestion key={27} />,
+      component: <ParentIntellectualDisability key={27} />,
     },
     {
       title: '放射線障害',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -17,6 +17,7 @@ import { SpousePhysicalDisability } from './questions/spousePhysicalDisability';
 import { ChildPhysicalDisability } from './questions/childPhysicalDisability';
 import { ParentPhysicalDisability } from './questions/parentPhysicalDisability';
 import { SelfIntellectualDisability } from './questions/selfIntellectualDisability';
+import { SpouseIntellectualDisability } from './questions/spouseIntellectualDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -290,7 +291,7 @@ const questions = {
     },
     {
       title: '療育手帳、愛の手帳',
-      component: <DummyQuestion key={27} />,
+      component: <SpouseIntellectualDisability key={27} />,
     },
     {
       title: '放射線障害',

--- a/dashboard/src/components/forms/questions/childIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/childIntellectualDisability.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { IntellectualDisability } from "./intellectualDisability";
+
+export const ChildIntellectualDisability = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <IntellectualDisability personName={`子ども${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/childIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/childIntellectualDisability.tsx
@@ -1,8 +1,10 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { IntellectualDisability } from "./intellectualDisability";
+import { IntellectualDisability } from './intellectualDisability';
 
 export const ChildIntellectualDisability = () => {
   const questionKey = useRecoilValue(questionKeyAtom);
-  return <IntellectualDisability personName={`子ども${questionKey.personNum}`} />;
+  return (
+    <IntellectualDisability personName={`子ども${questionKey.personNum}`} />
+  );
 };

--- a/dashboard/src/components/forms/questions/intellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/intellectualDisability.tsx
@@ -1,0 +1,57 @@
+import { useRecoilState, useRecoilValue } from "recoil";
+import { currentDateAtom, householdAtom } from "../../../state";
+import { SelectionQuestion } from "../templates/selectionQuestion";
+
+export const IntellectualDisability = ({ personName }: { personName: string }) => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  // display: 画面表示に使用
+  // value: OpenFisca APIに使用
+  // householdKey: householdオブジェクトに追加するキー
+  const items = [
+    { display: '療育手帳 A', value: 'A', householdKey: '療育手帳等級' },
+    { display: '療育手帳 B', value: 'B', householdKey: '療育手帳等級' },
+    { display: '愛の手帳 1度', value: '一度', householdKey: '愛の手帳等級' },
+    { display: '愛の手帳 2度', value: '二度', householdKey: '愛の手帳等級' },
+    { display: '愛の手帳 3度', value: '三度', householdKey: '愛の手帳等級' },
+    { display: '愛の手帳 4度', value: '四度', householdKey: '愛の手帳等級' },
+    { display: '上記以外／持っていない', value: '無', householdKey: '療育手帳等級' },
+  ];
+
+  const selections = items.map((item) => {
+    return {
+      selection: item.display,
+      onClick: () => {
+        const newHousehold = { ...household };
+        newHousehold.世帯員[personName][item.householdKey] = {
+          [currentDate]: item.value,
+        };
+
+        if (item.householdKey === '療育手帳等級') {
+          delete newHousehold.世帯員[personName].愛の手帳等級
+        }
+        if (item.householdKey === '愛の手帳等級') {
+          delete newHousehold.世帯員[personName].療育手帳等級
+        }
+        setHousehold({ ...newHousehold });
+      }
+    }
+  });
+
+  return (
+    <SelectionQuestion
+      title="療育手帳、または愛の手帳を持っていますか？"
+      selections={selections}
+      defaultSelection={({ household }: { household: any }) => {
+        const item = items.find((item) => {
+          const value = household.世帯員[personName][item.householdKey]
+            ? household.世帯員[personName][item.householdKey][currentDate]
+            : null
+          return item.value === value
+        });
+        return item?.display ?? null;
+      }}
+    />
+  )
+};

--- a/dashboard/src/components/forms/questions/intellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/intellectualDisability.tsx
@@ -1,8 +1,12 @@
-import { useRecoilState, useRecoilValue } from "recoil";
-import { currentDateAtom, householdAtom } from "../../../state";
-import { SelectionQuestion } from "../templates/selectionQuestion";
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentDateAtom, householdAtom } from '../../../state';
+import { SelectionQuestion } from '../templates/selectionQuestion';
 
-export const IntellectualDisability = ({ personName }: { personName: string }) => {
+export const IntellectualDisability = ({
+  personName,
+}: {
+  personName: string;
+}) => {
   const [household, setHousehold] = useRecoilState(householdAtom);
   const currentDate = useRecoilValue(currentDateAtom);
 
@@ -16,7 +20,11 @@ export const IntellectualDisability = ({ personName }: { personName: string }) =
     { display: '愛の手帳 2度', value: '二度', householdKey: '愛の手帳等級' },
     { display: '愛の手帳 3度', value: '三度', householdKey: '愛の手帳等級' },
     { display: '愛の手帳 4度', value: '四度', householdKey: '愛の手帳等級' },
-    { display: '上記以外／持っていない', value: '無', householdKey: '療育手帳等級' },
+    {
+      display: '上記以外／持っていない',
+      value: '無',
+      householdKey: '療育手帳等級',
+    },
   ];
 
   const selections = items.map((item) => {
@@ -29,14 +37,14 @@ export const IntellectualDisability = ({ personName }: { personName: string }) =
         };
 
         if (item.householdKey === '療育手帳等級') {
-          delete newHousehold.世帯員[personName].愛の手帳等級
+          delete newHousehold.世帯員[personName].愛の手帳等級;
         }
         if (item.householdKey === '愛の手帳等級') {
-          delete newHousehold.世帯員[personName].療育手帳等級
+          delete newHousehold.世帯員[personName].療育手帳等級;
         }
         setHousehold({ ...newHousehold });
-      }
-    }
+      },
+    };
   });
 
   return (
@@ -47,11 +55,11 @@ export const IntellectualDisability = ({ personName }: { personName: string }) =
         const item = items.find((item) => {
           const value = household.世帯員[personName][item.householdKey]
             ? household.世帯員[personName][item.householdKey][currentDate]
-            : null
-          return item.value === value
+            : null;
+          return item.value === value;
         });
         return item?.display ?? null;
       }}
     />
-  )
+  );
 };

--- a/dashboard/src/components/forms/questions/parentIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/parentIntellectualDisability.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { IntellectualDisability } from "./intellectualDisability";
+
+export const ParentIntellectualDisability = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <IntellectualDisability personName={`親${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/parentIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/parentIntellectualDisability.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { IntellectualDisability } from "./intellectualDisability";
+import { IntellectualDisability } from './intellectualDisability';
 
 export const ParentIntellectualDisability = () => {
   const questionKey = useRecoilValue(questionKeyAtom);

--- a/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
@@ -1,0 +1,43 @@
+import { useRecoilState, useRecoilValue } from "recoil";
+import { currentDateAtom, householdAtom } from "../../../state";
+import { SelectionQuestion } from "../templates/selectionQuestion";
+
+export const SelfIntellectualDisability = () => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  const items = [
+    { display: '療育手帳 A', value: 'A' },
+    { display: '療育手帳 B', value: 'B' },
+    { display: '愛の手帳 1度', value: '一度' },
+    { display: '愛の手帳 2度', value: '二度' },
+    { display: '愛の手帳 3度', value: '三度' },
+    { display: '愛の手帳 4度', value: '四度' },
+    { display: '上記以外／持っていない', value: '無' },
+  ];
+
+  const selections = items.map((item) => {
+    return {
+      selection: item.display,
+      onClick: () => {
+        const newHousehold = { ...household };
+        newHousehold.世帯員['あなた'].愛の手帳等級 = { // TODO: 選択項目に応じて「愛の手帳 or 療育手帳」を切り替えるようにする
+          [currentDate]: item.value,
+        };
+        setHousehold({ ...newHousehold });
+      }
+    }
+  });
+
+  return (
+    <SelectionQuestion
+      title="療育手帳、または愛の手帳を持っていますか？"
+      selections={selections}
+      defaultSelection={({ household }: { household: any }) =>
+        household.世帯員['あなた'].身体障害者手帳等級
+          ? household.世帯員['あなた'].身体障害者手帳等級[currentDate]
+          : null
+      }
+    />
+  )
+};

--- a/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
@@ -6,14 +6,17 @@ export const SelfIntellectualDisability = () => {
   const [household, setHousehold] = useRecoilState(householdAtom);
   const currentDate = useRecoilValue(currentDateAtom);
 
+  // display: 画面表示に使用
+  // value: OpenFisca APIに使用
+  // householdKey: householdオブジェクトに追加するキー
   const items = [
-    { display: '療育手帳 A', value: 'A' },
-    { display: '療育手帳 B', value: 'B' },
-    { display: '愛の手帳 1度', value: '一度' },
-    { display: '愛の手帳 2度', value: '二度' },
-    { display: '愛の手帳 3度', value: '三度' },
-    { display: '愛の手帳 4度', value: '四度' },
-    { display: '上記以外／持っていない', value: '無' },
+    { display: '療育手帳 A', value: 'A', householdKey: '療育手帳等級' },
+    { display: '療育手帳 B', value: 'B', householdKey: '療育手帳等級' },
+    { display: '愛の手帳 1度', value: '一度', householdKey: '愛の手帳等級' },
+    { display: '愛の手帳 2度', value: '二度', householdKey: '愛の手帳等級' },
+    { display: '愛の手帳 3度', value: '三度', householdKey: '愛の手帳等級' },
+    { display: '愛の手帳 4度', value: '四度', householdKey: '愛の手帳等級' },
+    { display: '上記以外／持っていない', value: '無', householdKey: '療育手帳等級' },
   ];
 
   const selections = items.map((item) => {
@@ -21,9 +24,16 @@ export const SelfIntellectualDisability = () => {
       selection: item.display,
       onClick: () => {
         const newHousehold = { ...household };
-        newHousehold.世帯員['あなた'].愛の手帳等級 = { // TODO: 選択項目に応じて「愛の手帳 or 療育手帳」を切り替えるようにする
+        newHousehold.世帯員['あなた'][item.householdKey] = {
           [currentDate]: item.value,
         };
+
+        if (item.householdKey === '療育手帳等級') {
+          delete newHousehold.世帯員['あなた'].愛の手帳等級
+        }
+        if (item.householdKey === '愛の手帳等級') {
+          delete newHousehold.世帯員['あなた'].療育手帳等級
+        }
         setHousehold({ ...newHousehold });
       }
     }
@@ -33,11 +43,15 @@ export const SelfIntellectualDisability = () => {
     <SelectionQuestion
       title="療育手帳、または愛の手帳を持っていますか？"
       selections={selections}
-      defaultSelection={({ household }: { household: any }) =>
-        household.世帯員['あなた'].身体障害者手帳等級
-          ? household.世帯員['あなた'].身体障害者手帳等級[currentDate]
-          : null
-      }
+      defaultSelection={({ household }: { household: any }) => {
+        const item = items.find((item) => {
+          const value = household.世帯員['あなた'][item.householdKey]
+            ? household.世帯員['あなた'][item.householdKey][currentDate]
+            : null
+          return item.value === value
+        });
+        return item?.display ?? null;
+      }}
     />
   )
 };

--- a/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
@@ -1,5 +1,5 @@
-import { IntellectualDisability } from "./intellectualDisability";
+import { IntellectualDisability } from './intellectualDisability';
 
 export const SelfIntellectualDisability = () => {
-  return <IntellectualDisability personName='あなた' />;
+  return <IntellectualDisability personName="あなた" />;
 };

--- a/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/selfIntellectualDisability.tsx
@@ -1,57 +1,5 @@
-import { useRecoilState, useRecoilValue } from "recoil";
-import { currentDateAtom, householdAtom } from "../../../state";
-import { SelectionQuestion } from "../templates/selectionQuestion";
+import { IntellectualDisability } from "./intellectualDisability";
 
 export const SelfIntellectualDisability = () => {
-  const [household, setHousehold] = useRecoilState(householdAtom);
-  const currentDate = useRecoilValue(currentDateAtom);
-
-  // display: 画面表示に使用
-  // value: OpenFisca APIに使用
-  // householdKey: householdオブジェクトに追加するキー
-  const items = [
-    { display: '療育手帳 A', value: 'A', householdKey: '療育手帳等級' },
-    { display: '療育手帳 B', value: 'B', householdKey: '療育手帳等級' },
-    { display: '愛の手帳 1度', value: '一度', householdKey: '愛の手帳等級' },
-    { display: '愛の手帳 2度', value: '二度', householdKey: '愛の手帳等級' },
-    { display: '愛の手帳 3度', value: '三度', householdKey: '愛の手帳等級' },
-    { display: '愛の手帳 4度', value: '四度', householdKey: '愛の手帳等級' },
-    { display: '上記以外／持っていない', value: '無', householdKey: '療育手帳等級' },
-  ];
-
-  const selections = items.map((item) => {
-    return {
-      selection: item.display,
-      onClick: () => {
-        const newHousehold = { ...household };
-        newHousehold.世帯員['あなた'][item.householdKey] = {
-          [currentDate]: item.value,
-        };
-
-        if (item.householdKey === '療育手帳等級') {
-          delete newHousehold.世帯員['あなた'].愛の手帳等級
-        }
-        if (item.householdKey === '愛の手帳等級') {
-          delete newHousehold.世帯員['あなた'].療育手帳等級
-        }
-        setHousehold({ ...newHousehold });
-      }
-    }
-  });
-
-  return (
-    <SelectionQuestion
-      title="療育手帳、または愛の手帳を持っていますか？"
-      selections={selections}
-      defaultSelection={({ household }: { household: any }) => {
-        const item = items.find((item) => {
-          const value = household.世帯員['あなた'][item.householdKey]
-            ? household.世帯員['あなた'][item.householdKey][currentDate]
-            : null
-          return item.value === value
-        });
-        return item?.display ?? null;
-      }}
-    />
-  )
+  return <IntellectualDisability personName='あなた' />;
 };

--- a/dashboard/src/components/forms/questions/spouseIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/spouseIntellectualDisability.tsx
@@ -1,5 +1,5 @@
-import { IntellectualDisability } from "./intellectualDisability";
+import { IntellectualDisability } from './intellectualDisability';
 
 export const SpouseIntellectualDisability = () => {
-  return <IntellectualDisability personName='配偶者' />;
+  return <IntellectualDisability personName="配偶者" />;
 };

--- a/dashboard/src/components/forms/questions/spouseIntellectualDisability.tsx
+++ b/dashboard/src/components/forms/questions/spouseIntellectualDisability.tsx
@@ -1,0 +1,5 @@
+import { IntellectualDisability } from "./intellectualDisability";
+
+export const SpouseIntellectualDisability = () => {
+  return <IntellectualDisability personName='配偶者' />;
+};


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は新UI「療育手帳または愛の手帳を持っている」コンポーネントを追加する
  - そのために世帯員毎に共通する手帳の等級を選択するコンポーネントとしてIntellectualDisabilityを追加した
  - そのためにSelfIntellectualDisability/SpouseIntellectualDisability/ChildIntellectualDisability/ParentIntellectualDisabilityを追加した

## 動作確認

- [x] 追加した部分の影響しそうな箇所を目視確認した
  - [x] 世帯員毎に「療育手帳、または愛の手帳を持っていますか？」画面が表示されること
  - [x] 等級を選択したらhouseholdステートが更新されること
  - [x] 全ての世帯員で等級を選択し/result画面でエラーが出ないこと
  - [x] 等級を選択して次の画面に遷移し、そこから戻った時に選択した等級のボタンが青色に塗り潰されていること

※ Chromeブラウザ / iPhoneSEサイズで確認しました

<img width="374" src="https://github.com/user-attachments/assets/ff6a56a3-e8a8-42ec-959b-bfd30da5df60" /> <img width="374" src="https://github.com/user-attachments/assets/2f5569e9-aa9f-4acc-b3b4-49b0dc979303" />
<img width="374" src="https://github.com/user-attachments/assets/a01dceef-1378-498a-87cf-97bec8a8f243" /> <img width="374" src="https://github.com/user-attachments/assets/11c92b7c-30cc-44ab-95af-8163fff0f1d5" />




