### PR TITLE
新UI質問: 「精神障害者手帳を持っている」を実装する

### DIFF
--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -22,6 +22,7 @@ import { ChildIntellectualDisability } from './questions/childIntellectualDisabi
 import { ParentIntellectualDisability } from './questions/parentIntellectualDisability';
 import { SelfMentalDisability } from './questions/selfMentalDisability';
 import { SpouseMentalDisability } from './questions/spouseMentalDisability';
+import { ChildMentalDisability } from './questions/childMentalDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -433,7 +434,7 @@ const questions = {
     },
     {
       title: '精神障害者手帳',
-      component: <DummyQuestion key={27} />,
+      component: <ChildMentalDisability key={27} />,
     },
     {
       title: '療育手帳、愛の手帳',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -23,6 +23,7 @@ import { ParentIntellectualDisability } from './questions/parentIntellectualDisa
 import { SelfMentalDisability } from './questions/selfMentalDisability';
 import { SpouseMentalDisability } from './questions/spouseMentalDisability';
 import { ChildMentalDisability } from './questions/childMentalDisability';
+import { ParentMentalDisability } from './questions/parentMentalDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -564,7 +565,7 @@ const questions = {
     },
     {
       title: '精神障害者手帳',
-      component: <DummyQuestion key={26} />,
+      component: <ParentMentalDisability key={26} />,
     },
     {
       title: '療育手帳、愛の手帳',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -21,6 +21,7 @@ import { SpouseIntellectualDisability } from './questions/spouseIntellectualDisa
 import { ChildIntellectualDisability } from './questions/childIntellectualDisability';
 import { ParentIntellectualDisability } from './questions/parentIntellectualDisability';
 import { SelfMentalDisability } from './questions/selfMentalDisability';
+import { SpouseMentalDisability } from './questions/spouseMentalDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -290,7 +291,7 @@ const questions = {
     },
     {
       title: '精神障害者手帳',
-      component: <DummyQuestion key={26} />,
+      component: <SpouseMentalDisability key={26} />,
     },
     {
       title: '療育手帳、愛の手帳',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -20,6 +20,7 @@ import { SelfIntellectualDisability } from './questions/selfIntellectualDisabili
 import { SpouseIntellectualDisability } from './questions/spouseIntellectualDisability';
 import { ChildIntellectualDisability } from './questions/childIntellectualDisability';
 import { ParentIntellectualDisability } from './questions/parentIntellectualDisability';
+import { SelfMentalDisability } from './questions/selfMentalDisability';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -135,7 +136,7 @@ const questions = {
     },
     {
       title: '精神障害者手帳',
-      component: <DummyQuestion key={27} />,
+      component: <SelfMentalDisability key={27} />,
     },
     {
       title: '療育手帳、愛の手帳',

--- a/dashboard/src/components/forms/questions/childMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/childMentalDisability.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { MentalDisability } from "./mentalDisability";
+import { MentalDisability } from './mentalDisability';
 
 export const ChildMentalDisability = () => {
   const questionKey = useRecoilValue(questionKeyAtom);

--- a/dashboard/src/components/forms/questions/childMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/childMentalDisability.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { MentalDisability } from "./mentalDisability";
+
+export const ChildMentalDisability = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <MentalDisability personName={`子ども${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/mentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/mentalDisability.tsx
@@ -37,7 +37,9 @@ export const MentalDisability = ({ personName }: { personName: string }) => {
           ? grades.find(
               (grade) =>
                 grade.value ===
-                household.世帯員[personName].精神障害者保健福祉手帳等級[currentDate]
+                household.世帯員[personName].精神障害者保健福祉手帳等級[
+                  currentDate
+                ]
             )?.display ?? null
           : null
       }

--- a/dashboard/src/components/forms/questions/mentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/mentalDisability.tsx
@@ -1,0 +1,46 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentDateAtom, householdAtom } from '../../../state';
+import { SelectionQuestion } from '../templates/selectionQuestion';
+
+export const MentalDisability = ({ personName }: { personName: string }) => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  // display: 画面表示に使用
+  // value: OpenFisca APIに使用(pythonは数字を頭にした変数名をつけられない)
+  const grades = [
+    { display: '1級', value: '一級' },
+    { display: '2級', value: '二級' },
+    { display: '3級', value: '三級' },
+    { display: '上記以外／持っていない', value: '無' },
+  ];
+
+  const selections = grades.map((grade) => {
+    return {
+      selection: grade.display,
+      onClick: () => {
+        const newHousehold = { ...household };
+        newHousehold.世帯員[personName].精神障害者保健福祉手帳等級 = {
+          [currentDate]: grade.value,
+        };
+        setHousehold({ ...newHousehold });
+      },
+    };
+  });
+
+  return (
+    <SelectionQuestion
+      title="精神障害者保健福祉手帳を持っていますか？"
+      selections={selections}
+      defaultSelection={({ household }: { household: any }) =>
+        household.世帯員[personName].精神障害者保健福祉手帳等級
+          ? grades.find(
+              (grade) =>
+                grade.value ===
+                household.世帯員[personName].精神障害者保健福祉手帳等級[currentDate]
+            )?.display ?? null
+          : null
+      }
+    />
+  );
+};

--- a/dashboard/src/components/forms/questions/parentMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/parentMentalDisability.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { MentalDisability } from "./mentalDisability";
+
+export const ParentMentalDisability = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <MentalDisability personName={`親${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/parentMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/parentMentalDisability.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { MentalDisability } from "./mentalDisability";
+import { MentalDisability } from './mentalDisability';
 
 export const ParentMentalDisability = () => {
   const questionKey = useRecoilValue(questionKeyAtom);

--- a/dashboard/src/components/forms/questions/selfMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/selfMentalDisability.tsx
@@ -1,4 +1,4 @@
-import { MentalDisability } from "./mentalDisability";
+import { MentalDisability } from './mentalDisability';
 
 export const SelfMentalDisability = () => {
   return <MentalDisability personName="あなた" />;

--- a/dashboard/src/components/forms/questions/selfMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/selfMentalDisability.tsx
@@ -1,0 +1,5 @@
+import { MentalDisability } from "./mentalDisability";
+
+export const SelfMentalDisability = () => {
+  return <MentalDisability personName="あなた" />;
+};

--- a/dashboard/src/components/forms/questions/spouseMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/spouseMentalDisability.tsx
@@ -1,4 +1,4 @@
-import { MentalDisability } from "./mentalDisability";
+import { MentalDisability } from './mentalDisability';
 
 export const SpouseMentalDisability = () => {
   return <MentalDisability personName="配偶者" />;

--- a/dashboard/src/components/forms/questions/spouseMentalDisability.tsx
+++ b/dashboard/src/components/forms/questions/spouseMentalDisability.tsx
@@ -1,0 +1,5 @@
+import { MentalDisability } from "./mentalDisability";
+
+export const SpouseMentalDisability = () => {
+  return <MentalDisability personName="配偶者" />;
+};


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は新UI「精神障害者保健福祉手帳を持っていますか？」コンポーネントを追加する
  - そのために世帯員毎に共通する手帳の等級を選択するコンポーネントとしてMentalDisabilityを追加した
  - そのためにSelfMentalDisability/SpouseMentalDisability/ChildMentalDisability/ParentMentalDisabilityを追加した

## 動作確認

- [x] 追加した部分の影響しそうな箇所を目視確認した
  - [x] 世帯員毎に「療育手帳、または愛の手帳を持っていますか？」画面が表示されること
  - [x] 等級を選択したらhouseholdステートが更新されること
  - [x] 全ての世帯員で等級を選択し/result画面でエラーが出ないこと
  - [x] 等級を選択して次の画面に遷移し、そこから戻った時に選択した等級のボタンが青色に塗り潰されていること

※ Chromeブラウザ / iPhoneSEサイズで確認しました


<img width="374" src="https://github.com/user-attachments/assets/430574d2-45b8-40cc-aec1-e7b25a8f3a2d" /> <img width="374" src="https://github.com/user-attachments/assets/29ffe034-b1e5-4e41-9ff7-2a4c2f1097f3" />
<img width="374" src="https://github.com/user-attachments/assets/d659fb5e-a318-45bd-8eb4-54df0c054915" /> <img width="374" src="https://github.com/user-attachments/assets/d483c713-4a83-46e7-93da-13390432a329" />




