### PR TITLE
SelectionQuestionにて選択済みの状態でもエラーメッセージが表示される問題を修正

### DIFF
--- a/dashboard/src/components/forms/templates/selectionQuestion.tsx
+++ b/dashboard/src/components/forms/templates/selectionQuestion.tsx
@@ -40,6 +40,9 @@ export const SelectionQuestion = ({
   const [questionValidated, setQuestionValidated] = useRecoilState(
     questionValidatedAtom
   );
+  if (selectionState !== null) {
+    setQuestionValidated(true);
+  }
 
   const btn = ({
     cond,

--- a/dashboard/src/components/forms/templates/selectionQuestion.tsx
+++ b/dashboard/src/components/forms/templates/selectionQuestion.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Box,
   FormControl,
@@ -40,9 +40,12 @@ export const SelectionQuestion = ({
   const [questionValidated, setQuestionValidated] = useRecoilState(
     questionValidatedAtom
   );
-  if (selectionState !== null) {
-    setQuestionValidated(true);
-  }
+
+  useEffect(() => {
+    if (selectionState !== null) {
+      setQuestionValidated(true);
+    }
+  }, [selectionState]);
 
   const btn = ({
     cond,
@@ -67,7 +70,6 @@ export const SelectionQuestion = ({
       _hover={{ bg: 'cyan.600', borderColor: 'cyan.900', color: 'white' }}
       onClick={() => {
         setSelectionState(selection);
-        setQuestionValidated(true);
         onClick();
       }}
     >


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は SelectionQuestion画面で選択済みの状態から「次へ」をタップするとエラーメッセージが表示される問題 を改善する
  - そのために SelectionQuestionでdefaultSelectionがnullでない場合はquestionValidatedをtrueにする処理 を追加した

**補足**
https://github.com/project-inclusive/OpenFisca-Japan/issues/389#issuecomment-3194085190 で質問した件です。
「前へ」ボタンをタップしたら状態が破棄されているかと思ったのですが、questionValidatedが更新されていないだけでした。

**問題の再現方法**
1. 任意のSelectionQuestion画面（ex. 障害者手帳選択画面）を開く
2. いずれかのボタンをタップする
3. 前へボタンをタップする
4. 次へボタンをタップする
5. No.2で選択したボタンがアクティブになっていることを確認し、次へボタンをタップする
6. 「入力必須項目です」というエラーメッセージが出て画面遷移できない（正しくは、ボタンが選択されている状態なのでエラーメッセージが表示されない且つ次の画面に遷移できる）

![selection_question](https://github.com/user-attachments/assets/1c9d1005-68fa-4762-843b-387a91b95569)


## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
  - [x] 上記問題が解消されている
  - [x] 初回表示時（未選択状態時）に次へボタンをタップするとエラーメッセージが表示される

※ 障害者手帳等級を選択する画面で確認
