### PR TITLE
新UI質問: 「放射線障害がある」を実装する

### DIFF
--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -26,6 +26,7 @@ import { ChildMentalDisability } from './questions/childMentalDisability';
 import { ParentMentalDisability } from './questions/parentMentalDisability';
 import { SelfRadiationDamage } from './questions/selfRadiationDamage';
 import { SpouseRadiationDamage } from './questions/spouseRadiationDamage';
+import { ChildRadiationDamage } from './questions/childRadiationDamage';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -445,7 +446,7 @@ const questions = {
     },
     {
       title: '放射線障害',
-      component: <DummyQuestion key={29} />,
+      component: <ChildRadiationDamage key={29} />,
     },
     {
       title: '内部障害',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -24,6 +24,7 @@ import { SelfMentalDisability } from './questions/selfMentalDisability';
 import { SpouseMentalDisability } from './questions/spouseMentalDisability';
 import { ChildMentalDisability } from './questions/childMentalDisability';
 import { ParentMentalDisability } from './questions/parentMentalDisability';
+import { SelfRadiationDamage } from './questions/selfRadiationDamage';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -147,7 +148,7 @@ const questions = {
     },
     {
       title: '放射線障害',
-      component: <DummyQuestion key={29} />,
+      component: <SelfRadiationDamage key={29} />,
     },
     {
       title: '内部障害',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -27,6 +27,7 @@ import { ParentMentalDisability } from './questions/parentMentalDisability';
 import { SelfRadiationDamage } from './questions/selfRadiationDamage';
 import { SpouseRadiationDamage } from './questions/spouseRadiationDamage';
 import { ChildRadiationDamage } from './questions/childRadiationDamage';
+import { ParentRadiationDamage } from './questions/parentRadiationDamage';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -576,7 +577,7 @@ const questions = {
     },
     {
       title: '放射線障害',
-      component: <DummyQuestion key={28} />,
+      component: <ParentRadiationDamage key={28} />,
     },
     {
       title: '内部障害',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -25,6 +25,7 @@ import { SpouseMentalDisability } from './questions/spouseMentalDisability';
 import { ChildMentalDisability } from './questions/childMentalDisability';
 import { ParentMentalDisability } from './questions/parentMentalDisability';
 import { SelfRadiationDamage } from './questions/selfRadiationDamage';
+import { SpouseRadiationDamage } from './questions/spouseRadiationDamage';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -302,7 +303,7 @@ const questions = {
     },
     {
       title: '放射線障害',
-      component: <DummyQuestion key={28} />,
+      component: <SpouseRadiationDamage key={28} />,
     },
     {
       title: '内部障害',

--- a/dashboard/src/components/forms/questions/childRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/childRadiationDamage.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { RadiationDamage } from "./radiationDamage";
+import { RadiationDamage } from './radiationDamage';
 
 export const ChildRadiationDamage = () => {
   const questionKey = useRecoilValue(questionKeyAtom);

--- a/dashboard/src/components/forms/questions/childRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/childRadiationDamage.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { RadiationDamage } from "./radiationDamage";
+
+export const ChildRadiationDamage = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <RadiationDamage personName={`子ども${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/parentRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/parentRadiationDamage.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { RadiationDamage } from "./radiationDamage";
+
+export const ParentRadiationDamage = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <RadiationDamage personName={`親${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/parentRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/parentRadiationDamage.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { RadiationDamage } from "./radiationDamage";
+import { RadiationDamage } from './radiationDamage';
 
 export const ParentRadiationDamage = () => {
   const questionKey = useRecoilValue(questionKeyAtom);

--- a/dashboard/src/components/forms/questions/radiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/radiationDamage.tsx
@@ -1,0 +1,45 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentDateAtom, householdAtom } from '../../../state';
+import { SelectionQuestion } from '../templates/selectionQuestion';
+
+export const RadiationDamage = ({ personName }: { personName: string }) => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  // display: 画面表示に使用
+  // value: OpenFisca APIに使用
+  const items = [
+    { display: '現罹患者', value: '現罹患者' },
+    { display: '元罹患者', value: '元罹患者' },
+    { display: 'いいえ', value: '無' },
+  ];
+
+  const selections = items.map((item) => {
+    return {
+      selection: item.display,
+      onClick: () => {
+        const newHousehold = { ...household };
+        newHousehold.世帯員[personName].放射線障害 = {
+          [currentDate]: item.value,
+        };
+        setHousehold({ ...newHousehold });
+      },
+    };
+  });
+
+  return (
+    <SelectionQuestion
+      title="放射線障害がありますか？"
+      selections={selections}
+      defaultSelection={({ household }: { household: any }) =>
+        household.世帯員[personName].放射線障害
+          ? items.find(
+              (item) =>
+                item.value ===
+                household.世帯員[personName].放射線障害[currentDate]
+            )?.display ?? null
+          : null
+      }
+    />
+  );
+};

--- a/dashboard/src/components/forms/questions/selfRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/selfRadiationDamage.tsx
@@ -1,0 +1,5 @@
+import { RadiationDamage } from "./radiationDamage";
+
+export const SelfRadiationDamage = () => {
+  return <RadiationDamage personName="あなた" />;
+}

--- a/dashboard/src/components/forms/questions/selfRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/selfRadiationDamage.tsx
@@ -1,5 +1,5 @@
-import { RadiationDamage } from "./radiationDamage";
+import { RadiationDamage } from './radiationDamage';
 
 export const SelfRadiationDamage = () => {
   return <RadiationDamage personName="あなた" />;
-}
+};

--- a/dashboard/src/components/forms/questions/spouseRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/spouseRadiationDamage.tsx
@@ -1,4 +1,4 @@
-import { RadiationDamage } from "./radiationDamage";
+import { RadiationDamage } from './radiationDamage';
 
 export const SpouseRadiationDamage = () => {
   return <RadiationDamage personName="配偶者" />;

--- a/dashboard/src/components/forms/questions/spouseRadiationDamage.tsx
+++ b/dashboard/src/components/forms/questions/spouseRadiationDamage.tsx
@@ -1,0 +1,5 @@
+import { RadiationDamage } from "./radiationDamage";
+
+export const SpouseRadiationDamage = () => {
+  return <RadiationDamage personName="配偶者" />;
+};


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は 新UI「放射線障害がありますか？」コンポーネント を追加する
  - そのために 世帯員毎に共通する罹患状態を選択するコンポーネントとしてRadiationDamage を追加した
  - そのために SelfRadiationDamage/SpouseRadiationDamage/ChildRadiationDamage/ParentRadiationDamage を追加した

## 動作確認

- [x] 追加した部分の影響しそうな箇所を目視確認した
  - [x] 世帯員毎に「放射線障害がありますか？」画面が表示されること
  - [x] 罹患状態を選択したらhouseholdステートが更新されること
  - [x] 全ての世帯員で罹患状態を選択し/result画面でエラーが出ないこと
  - [x] 罹患状態を選択して次の画面に遷移し、そこから戻った時に選択したボタンが青色に塗り潰されていること
  - [x] chrome dev toolのコンソール画面に追加したコンポーネントのwarningやerrorが出力されていないこと

※ Chromeブラウザ / iPhoneSEサイズで確認しました

<img width="374" src="https://github.com/user-attachments/assets/7a311319-2063-4e66-bbb2-72e0234999ac" /> <img width="374" src="https://github.com/user-attachments/assets/30bad45d-e94f-406e-84a8-457b859bcf44" />
<img width="374" src="https://github.com/user-attachments/assets/2a1f9672-0263-44bc-ad0c-2720e0fd31a9" /> <img width="374" src="https://github.com/user-attachments/assets/3c0fd9fe-53d8-4a81-a5a2-07598a9dd130" />



