### PR TITLE
[WIP] 新UI質問: 「脳性まひ、または進行性筋萎縮症である」を実装する

### DIFF
--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -33,6 +33,7 @@ import { SpouseRadiationDamage } from './questions/spouseRadiationDamage';
 import { ChildRadiationDamage } from './questions/childRadiationDamage';
 import { ParentRadiationDamage } from './questions/parentRadiationDamage';
 import { SelfCerebralParalysis } from './questions/selfCerebralParalysis';
+import { SpouseCerebralParalysis } from './questions/spouseCerebralParalysis';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -318,7 +319,7 @@ const questions = {
     },
     {
       title: '脳性まひ',
-      component: <DummyQuestion key={30} />,
+      component: <SpouseCerebralParalysis key={30} />,
     },
     {
       title: '介護施設',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -34,6 +34,7 @@ import { ChildRadiationDamage } from './questions/childRadiationDamage';
 import { ParentRadiationDamage } from './questions/parentRadiationDamage';
 import { SelfCerebralParalysis } from './questions/selfCerebralParalysis';
 import { SpouseCerebralParalysis } from './questions/spouseCerebralParalysis';
+import { ChildCerebralParalysis } from './questions/childCerebralParalysis';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -461,7 +462,7 @@ const questions = {
     },
     {
       title: '脳性まひ',
-      component: <DummyQuestion key={31} />,
+      component: <ChildCerebralParalysis key={31} />,
     },
     {
       title: '介護施設',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -35,6 +35,7 @@ import { ParentRadiationDamage } from './questions/parentRadiationDamage';
 import { SelfCerebralParalysis } from './questions/selfCerebralParalysis';
 import { SpouseCerebralParalysis } from './questions/spouseCerebralParalysis';
 import { ChildCerebralParalysis } from './questions/childCerebralParalysis';
+import { ParentCerebralParalysis } from './questions/parentCerebralParalysis';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -592,7 +593,7 @@ const questions = {
     },
     {
       title: '脳性まひ',
-      component: <DummyQuestion key={30} />,
+      component: <ParentCerebralParalysis key={30} />,
     },
     {
       title: '介護施設',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -32,6 +32,7 @@ import { SelfRadiationDamage } from './questions/selfRadiationDamage';
 import { SpouseRadiationDamage } from './questions/spouseRadiationDamage';
 import { ChildRadiationDamage } from './questions/childRadiationDamage';
 import { ParentRadiationDamage } from './questions/parentRadiationDamage';
+import { SelfCerebralParalysis } from './questions/selfCerebralParalysis';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -163,7 +164,7 @@ const questions = {
     },
     {
       title: '脳性まひ',
-      component: <DummyQuestion key={31} />,
+      component: <SelfCerebralParalysis key={31} />,
     },
     {
       title: '介護施設',

--- a/dashboard/src/components/forms/questions/cerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/cerebralParalysis.tsx
@@ -28,8 +28,16 @@ export const CerebralParalysis = ({ personName }: { personName: string }) => {
       yesOnClick={yesOnClick}
       noOnClick={noOnClick}
       defaultSelection={({ household }: { household: any }) => {
-        if (household.世帯員[personName]?.脳性まひ_進行性筋萎縮症?.[currentDate] != null) {
-          return household.世帯員[personName].脳性まひ_進行性筋萎縮症[currentDate] === '有';
+        if (
+          household.世帯員[personName]?.脳性まひ_進行性筋萎縮症?.[
+            currentDate
+          ] != null
+        ) {
+          return (
+            household.世帯員[personName].脳性まひ_進行性筋萎縮症[
+              currentDate
+            ] === '有'
+          );
         }
         return null;
       }}

--- a/dashboard/src/components/forms/questions/cerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/cerebralParalysis.tsx
@@ -1,0 +1,38 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { YesNoQuestion } from '../templates/yesNoQuestion';
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const CerebralParalysis = ({ personName }: { personName: string }) => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  const yesOnClick = () => {
+    const newHousehold = { ...household };
+    newHousehold.世帯員[personName].脳性まひ_進行性筋萎縮症 = {
+      [currentDate]: '有',
+    };
+    setHousehold(newHousehold);
+  };
+
+  const noOnClick = () => {
+    const newHousehold = { ...household };
+    newHousehold.世帯員[personName].脳性まひ_進行性筋萎縮症 = {
+      [currentDate]: '無',
+    };
+    setHousehold(newHousehold);
+  };
+
+  return (
+    <YesNoQuestion
+      title="脳性まひ、または進行性筋萎縮症ですか？"
+      yesOnClick={yesOnClick}
+      noOnClick={noOnClick}
+      defaultSelection={({ household }: { household: any }) => {
+        if (household.世帯員[personName]?.脳性まひ_進行性筋萎縮症?.[currentDate] != null) {
+          return household.世帯員[personName].脳性まひ_進行性筋萎縮症[currentDate] === '有';
+        }
+        return null;
+      }}
+    />
+  );
+};

--- a/dashboard/src/components/forms/questions/childCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/childCerebralParalysis.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { CerebralParalysis } from "./cerebralParalysis";
+import { CerebralParalysis } from './cerebralParalysis';
 
 export const ChildCerebralParalysis = () => {
   const questionKey = useRecoilValue(questionKeyAtom);

--- a/dashboard/src/components/forms/questions/childCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/childCerebralParalysis.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { CerebralParalysis } from "./cerebralParalysis";
+
+export const ChildCerebralParalysis = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <CerebralParalysis personName={`子ども${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/parentCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/parentCerebralParalysis.tsx
@@ -1,6 +1,6 @@
 import { useRecoilValue } from 'recoil';
 import { questionKeyAtom } from '../../../state';
-import { CerebralParalysis } from "./cerebralParalysis";
+import { CerebralParalysis } from './cerebralParalysis';
 
 export const ParentCerebralParalysis = () => {
   const questionKey = useRecoilValue(questionKeyAtom);

--- a/dashboard/src/components/forms/questions/parentCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/parentCerebralParalysis.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { CerebralParalysis } from "./cerebralParalysis";
+
+export const ParentCerebralParalysis = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <CerebralParalysis personName={`親${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/selfCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/selfCerebralParalysis.tsx
@@ -1,4 +1,4 @@
-import { CerebralParalysis } from "./cerebralParalysis";
+import { CerebralParalysis } from './cerebralParalysis';
 
 export const SelfCerebralParalysis = () => {
   return <CerebralParalysis personName="あなた" />;

--- a/dashboard/src/components/forms/questions/selfCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/selfCerebralParalysis.tsx
@@ -1,0 +1,5 @@
+import { CerebralParalysis } from "./cerebralParalysis";
+
+export const SelfCerebralParalysis = () => {
+  return <CerebralParalysis personName="あなた" />;
+};

--- a/dashboard/src/components/forms/questions/spouseCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/spouseCerebralParalysis.tsx
@@ -1,0 +1,5 @@
+import { CerebralParalysis } from "./cerebralParalysis";
+
+export const SpouseCerebralParalysis = () => {
+  return <CerebralParalysis personName="配偶者" />;
+};

--- a/dashboard/src/components/forms/questions/spouseCerebralParalysis.tsx
+++ b/dashboard/src/components/forms/questions/spouseCerebralParalysis.tsx
@@ -1,4 +1,4 @@
-import { CerebralParalysis } from "./cerebralParalysis";
+import { CerebralParalysis } from './cerebralParalysis';
 
 export const SpouseCerebralParalysis = () => {
   return <CerebralParalysis personName="配偶者" />;


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は 新UI「脳性まひ、または進行性筋萎縮症ですか？」コンポーネント を追加する
  - そのために 世帯員毎に共通するyes/noを選択するコンポーネントとしてCerebralParalysis を追加した
  - そのために SelfCerebralParalysis/SpouseCerebralParalysis/ChildCerebralParalysis/ParentCerebralParalysis を追加した

## 動作確認

- [ ] 追加した部分の影響しそうな箇所を目視確認した
  - [ ] 世帯員毎に「脳性まひ、または進行性筋萎縮症ですか？」画面が表示されること
  - [ ] 脳性まひ等の有無を選択したらhouseholdステートが更新されること
  - [ ] 全ての世帯員で脳性まひ等の有無を選択し/result画面でエラーが出ないこと
  - [ ] 脳性まひ等の有無を選択して次の画面に遷移し、そこから戻った時に選択したボタンが青色に塗り潰されていること
  - [ ] chrome dev toolのコンソール画面に追加したコンポーネントのwarningやerrorが出力されていないこと

※ Chromeブラウザ / iPhoneSEサイズで確認しました

<img width="374" src="https://github.com/user-attachments/assets/5f630b15-a373-46a4-92c5-0cbe64b0052c" /> <img width="374" src="https://github.com/user-attachments/assets/e530efdc-6b23-4f82-b61d-7511cb6fb3ba" />
<img width="374" src="https://github.com/user-attachments/assets/0f053c1e-e83f-401d-ba02-c85881a0d2d6" /> <img width="374" src="https://github.com/user-attachments/assets/09416e48-a45e-46b7-97fb-7c7887f14daf" />




