### PR TITLE
新UI質問: 「介護施設に入所している」を実装する

### DIFF
--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -37,6 +37,7 @@ import { SpouseCerebralParalysis } from './questions/spouseCerebralParalysis';
 import { ChildCerebralParalysis } from './questions/childCerebralParalysis';
 import { ParentCerebralParalysis } from './questions/parentCerebralParalysis';
 import { SelfNursingHome } from './questions/selfNursingHome';
+import { SpouseNursingHome } from './questions/spouseNursingHome';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -326,7 +327,7 @@ const questions = {
     },
     {
       title: '介護施設',
-      component: <DummyQuestion key={31} />,
+      component: <SpouseNursingHome key={31} />,
     },
     {
       title: '妊娠',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -39,6 +39,7 @@ import { ParentCerebralParalysis } from './questions/parentCerebralParalysis';
 import { SelfNursingHome } from './questions/selfNursingHome';
 import { SpouseNursingHome } from './questions/spouseNursingHome';
 import { ChildNursingHome } from './questions/childNursingHome';
+import { ParentNursingHome } from './questions/parentNursingHome';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -600,7 +601,7 @@ const questions = {
     },
     {
       title: '介護施設',
-      component: <DummyQuestion key={31} />,
+      component: <ParentNursingHome key={31} />,
     },
   ],
 };

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -36,6 +36,7 @@ import { SelfCerebralParalysis } from './questions/selfCerebralParalysis';
 import { SpouseCerebralParalysis } from './questions/spouseCerebralParalysis';
 import { ChildCerebralParalysis } from './questions/childCerebralParalysis';
 import { ParentCerebralParalysis } from './questions/parentCerebralParalysis';
+import { SelfNursingHome } from './questions/selfNursingHome';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -171,7 +172,7 @@ const questions = {
     },
     {
       title: '介護施設',
-      component: <DummyQuestion key={32} />,
+      component: <SelfNursingHome key={32} />,
     },
     {
       title: '学生かどうか',

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -38,6 +38,7 @@ import { ChildCerebralParalysis } from './questions/childCerebralParalysis';
 import { ParentCerebralParalysis } from './questions/parentCerebralParalysis';
 import { SelfNursingHome } from './questions/selfNursingHome';
 import { SpouseNursingHome } from './questions/spouseNursingHome';
+import { ChildNursingHome } from './questions/childNursingHome';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -469,7 +470,7 @@ const questions = {
     },
     {
       title: '介護施設',
-      component: <DummyQuestion key={32} />,
+      component: <ChildNursingHome key={32} />,
     },
   ],
   親: [

--- a/dashboard/src/components/forms/questions/childNursingHome.tsx
+++ b/dashboard/src/components/forms/questions/childNursingHome.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { NursingHome } from './nursingHome';
+
+export const ChildNursingHome = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <NursingHome personName={`子ども${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/nursingHome.tsx
+++ b/dashboard/src/components/forms/questions/nursingHome.tsx
@@ -1,0 +1,40 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { YesNoQuestion } from '../templates/yesNoQuestion';
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const NursingHome = ({ personName }: { personName: string }) => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  const yesOnClick = () => {
+    const newHousehold = { ...household };
+    newHousehold.世帯員[personName].介護施設入所中 = {
+      [currentDate]: true,
+    };
+    setHousehold(newHousehold);
+  };
+
+  const noOnClick = () => {
+    const newHousehold = { ...household };
+    newHousehold.世帯員[personName].介護施設入所中 = {
+      [currentDate]: false,
+    };
+    setHousehold(newHousehold);
+  };
+
+  return (
+    <YesNoQuestion
+      title="介護施設に入所していますか？"
+      yesOnClick={yesOnClick}
+      noOnClick={noOnClick}
+      defaultSelection={({ household }: { household: any }) => {
+        if (
+          household.世帯員[personName]?.介護施設入所中?.[currentDate] != null
+        ) {
+          return household.世帯員[personName].介護施設入所中[currentDate];
+        }
+        return null;
+      }}
+    />
+  );
+};

--- a/dashboard/src/components/forms/questions/parentNursingHome.tsx
+++ b/dashboard/src/components/forms/questions/parentNursingHome.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { NursingHome } from './nursingHome';
+
+export const ParentNursingHome = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <NursingHome personName={`親${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/selfNursingHome.tsx
+++ b/dashboard/src/components/forms/questions/selfNursingHome.tsx
@@ -1,0 +1,5 @@
+import { NursingHome } from './nursingHome';
+
+export const SelfNursingHome = () => {
+  return <NursingHome personName="あなた" />;
+};

--- a/dashboard/src/components/forms/questions/spouseNursingHome.tsx
+++ b/dashboard/src/components/forms/questions/spouseNursingHome.tsx
@@ -1,0 +1,5 @@
+import { NursingHome } from './nursingHome';
+
+export const SpouseNursingHome = () => {
+  return <NursingHome personName="配偶者" />;
+};


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は 新UI「介護施設に入所していますか？」コンポーネント を追加する
  - そのために 世帯員毎に共通するyes/noを選択するコンポーネントとしてNursingHome を追加した
  - そのために SelfNursingHome/SpouseNursingHome/ChildNursingHome/ParentNursingHome を追加した

## 動作確認

- [x] 追加した部分の影響しそうな箇所を目視確認した
  - [x] 世帯員毎に「介護施設に入所していますか？」画面が表示されること
  - [x] 介護施設入所の有無を選択したらhouseholdステートが更新されること
  - [x] 全ての世帯員で介護施設入所の有無を選択し/result画面でエラーが出ないこと
  - [x] 介護施設入所の有無を選択して次の画面に遷移し、そこから戻った時に選択したボタンが青色に塗り潰されていること
  - [x] chrome dev toolのコンソール画面に追加したコンポーネントのwarningやerrorが出力されていないこと

※ Chromeブラウザ / iPhoneSEサイズで確認しました

<img width="374" src="https://github.com/user-attachments/assets/210bd298-78ba-4dda-bd3d-67800fb2c53e" /> <img width="374" src="https://github.com/user-attachments/assets/53f3f643-4f7c-4994-82c3-da2d488347d8" />
<img width="374" src="https://github.com/user-attachments/assets/b4ddb91e-7365-4459-b622-ac0ee087f8bf" /> <img width="374" src="https://github.com/user-attachments/assets/5138e76b-1359-4828-8102-5b76a279e1b1" />



