### PR TITLE
[WIP] 新UI質問: 「妊娠中である」を実装する

### DIFF
--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -41,6 +41,8 @@ import { SelfNursingHome } from './questions/selfNursingHome';
 import { SpouseNursingHome } from './questions/spouseNursingHome';
 import { ChildNursingHome } from './questions/childNursingHome';
 import { ParentNursingHome } from './questions/parentNursingHome';
+import { SelfPregnancy } from './questions/selfPregnancy';
+import { SpousePregnancy } from './questions/spousePregnancy';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -188,7 +190,7 @@ const questions = {
     },
     {
       title: '妊娠',
-      component: <DummyQuestion key={35} />,
+      component: <SelfPregnancy key={35} />,
     },
     {
       title: '配偶者の有無',
@@ -334,7 +336,7 @@ const questions = {
     },
     {
       title: '妊娠',
-      component: <DummyQuestion key={32} />,
+      component: <SpousePregnancy key={32} />,
     },
     {
       title: '配偶者がいるがひとり親に該当',

--- a/dashboard/src/components/forms/questions/pregnancy.tsx
+++ b/dashboard/src/components/forms/questions/pregnancy.tsx
@@ -1,0 +1,45 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentDateAtom, householdAtom } from '../../../state';
+import { SelectionQuestion } from '../templates/selectionQuestion';
+
+export const Pregnancy = ({ personName }: { personName: string }) => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  // display: 画面表示に使用
+  // value: OpenFisca APIに使用
+  const items = [
+    { display: '妊娠6ヵ月未満', value: '妊娠6ヵ月未満' },
+    { display: '妊娠6ヵ月以上', value: '妊娠6ヵ月以上' },
+    { display: '産後6ヵ月以内', value: '産後6ヵ月以内' },
+    { display: 'いいえ', value: '無' },
+  ];
+
+  const selections = items.map((item) => {
+    return {
+      selection: item.display,
+      onClick: () => {
+        const newHousehold = { ...household };
+        newHousehold.世帯員[personName].妊産婦 = {
+          [currentDate]: item.value,
+        };
+        setHousehold({ ...newHousehold });
+      },
+    };
+  });
+
+  return (
+    <SelectionQuestion
+      title="妊娠中、または産後6ヵ月以内ですか？"
+      selections={selections}
+      defaultSelection={({ household }: { household: any }) =>
+        household.世帯員[personName].妊産婦
+          ? items.find(
+              (item) =>
+                item.value === household.世帯員[personName].妊産婦[currentDate]
+            )?.display ?? null
+          : null
+      }
+    />
+  );
+};

--- a/dashboard/src/components/forms/questions/selfPregnancy.tsx
+++ b/dashboard/src/components/forms/questions/selfPregnancy.tsx
@@ -1,0 +1,5 @@
+import { Pregnancy } from './pregnancy';
+
+export const SelfPregnancy = () => {
+  return <Pregnancy personName="あなた" />;
+};

--- a/dashboard/src/components/forms/questions/spousePregnancy.tsx
+++ b/dashboard/src/components/forms/questions/spousePregnancy.tsx
@@ -1,0 +1,5 @@
+import { Pregnancy } from './pregnancy';
+
+export const SpousePregnancy = () => {
+  return <Pregnancy personName="配偶者" />;
+};


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は 新UI「妊娠中、または産後6ヵ月以内ですか？」コンポーネント を追加する
  - そのために 妊産婦かどうかを選択するコンポーネントとしてPregnancy を追加した
  - そのために SelfPregnancy/SpousePregnancy を追加した

## 動作確認

- [ ] 追加した部分の影響しそうな箇所を目視確認した
  - [x] 「世帯員あなた・配偶者」に「妊娠中、または産後6ヵ月以内ですか？」画面が表示されること
  - [ ] 各ステータスを選択したらhouseholdステートが更新されること
  - [x] 各ステータスを選択し/result画面でエラーが出ないこと
  - [ ] 各ステータスを選択して次の画面に遷移し、そこから戻った時に選択したボタンが青色に塗り潰されていること
  - [ ] chrome dev toolのコンソール画面に追加したコンポーネントのwarningやerrorが出力されていないこと

※ Chromeブラウザ / iPhoneSEサイズで確認しました

<img width="374" src="https://github.com/user-attachments/assets/260055e7-4545-4e7c-90ef-62a4df080eac" /> <img width="374" src="https://github.com/user-attachments/assets/9e9a5f2e-0a92-494c-9903-a77f6236c6d6" />


