### PR TITLE
新UI質問: 「学生である」を実装する

### DIFF
--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -45,6 +45,7 @@ import { SelfPregnancy } from './questions/selfPregnancy';
 import { SpousePregnancy } from './questions/spousePregnancy';
 import { SelfStudent } from './questions/selfStudent';
 import { SpouseStudent } from './questions/spouseStudent';
+import { ParentStudent } from './questions/parentStudent';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -611,6 +612,10 @@ const questions = {
     {
       title: '介護施設',
       component: <ParentNursingHome key={31} />,
+    },
+    {
+      title: '学生かどうか',
+      component: <ParentStudent key={32} />,
     },
   ],
 };

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -44,6 +44,7 @@ import { ParentNursingHome } from './questions/parentNursingHome';
 import { SelfPregnancy } from './questions/selfPregnancy';
 import { SpousePregnancy } from './questions/spousePregnancy';
 import { SelfStudent } from './questions/selfStudent';
+import { SpouseStudent } from './questions/spouseStudent';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -336,12 +337,16 @@ const questions = {
       component: <SpouseNursingHome key={31} />,
     },
     {
+      title: '学生かどうか',
+      component: <SpouseStudent key={32} />,
+    },
+    {
       title: '妊娠',
-      component: <SpousePregnancy key={32} />, // TODO: 「あなた」「配偶者」いずれか一方のみ妊産婦を選択できるようにしたい
+      component: <SpousePregnancy key={33} />, // TODO: 「あなた」「配偶者」いずれか一方のみ妊産婦を選択できるようにしたい
     },
     {
       title: '配偶者がいるがひとり親に該当',
-      component: <DummyQuestion key={33} />,
+      component: <DummyQuestion key={34} />,
     },
   ],
   子ども: [

--- a/dashboard/src/components/forms/detailedQuestionList.tsx
+++ b/dashboard/src/components/forms/detailedQuestionList.tsx
@@ -43,6 +43,7 @@ import { ChildNursingHome } from './questions/childNursingHome';
 import { ParentNursingHome } from './questions/parentNursingHome';
 import { SelfPregnancy } from './questions/selfPregnancy';
 import { SpousePregnancy } from './questions/spousePregnancy';
+import { SelfStudent } from './questions/selfStudent';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -182,7 +183,7 @@ const questions = {
     },
     {
       title: '学生かどうか',
-      component: <DummyQuestion key={33} />,
+      component: <SelfStudent key={33} />,
     },
     {
       title: '家を借りたい',

--- a/dashboard/src/components/forms/questions/parentStudent.tsx
+++ b/dashboard/src/components/forms/questions/parentStudent.tsx
@@ -1,0 +1,8 @@
+import { useRecoilValue } from 'recoil';
+import { questionKeyAtom } from '../../../state';
+import { Student } from './student';
+
+export const ParentStudent = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  return <Student personName={`親${questionKey.personNum}`} />;
+};

--- a/dashboard/src/components/forms/questions/selfStudent.tsx
+++ b/dashboard/src/components/forms/questions/selfStudent.tsx
@@ -1,0 +1,5 @@
+import { Student } from './student';
+
+export const SelfStudent = () => {
+  return <Student personName="あなた" />;
+};

--- a/dashboard/src/components/forms/questions/spouseStudent.tsx
+++ b/dashboard/src/components/forms/questions/spouseStudent.tsx
@@ -1,0 +1,5 @@
+import { Student } from './student';
+
+export const SpouseStudent = () => {
+  return <Student personName="配偶者" />;
+};

--- a/dashboard/src/components/forms/questions/student.tsx
+++ b/dashboard/src/components/forms/questions/student.tsx
@@ -1,0 +1,38 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { YesNoQuestion } from '../templates/yesNoQuestion';
+import { currentDateAtom, householdAtom } from '../../../state';
+
+export const Student = ({ personName }: { personName: string }) => {
+  const [household, setHousehold] = useRecoilState(householdAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+
+  const yesOnClick = () => {
+    const newHousehold = { ...household };
+    newHousehold.世帯員[personName].学生 = {
+      [currentDate]: true,
+    };
+    setHousehold(newHousehold);
+  };
+
+  const noOnClick = () => {
+    const newHousehold = { ...household };
+    newHousehold.世帯員[personName].学生 = {
+      [currentDate]: false,
+    };
+    setHousehold(newHousehold);
+  };
+
+  return (
+    <YesNoQuestion
+      title="高校、大学、専門学校、職業訓練学校等の学生ですか？"
+      yesOnClick={yesOnClick}
+      noOnClick={noOnClick}
+      defaultSelection={({ household }: { household: any }) => {
+        if (household.世帯員[personName]?.学生?.[currentDate] != null) {
+          return household.世帯員[personName].学生[currentDate];
+        }
+        return null;
+      }}
+    />
+  );
+};


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。
  - developではなくUI開発用のブランチdev_new_gui へ反映 

## 概要

- この Pull request は 新UI「高校、大学、専門学校、職業訓練学校等の学生ですか？」コンポーネント を追加する
  - そのために 学生かどうかを選択するコンポーネントとしてStudent を追加した
  - そのために SelfStudent/SpouseStudent/ParentStudent を変更した

## 動作確認

- [x] 追加した部分の影響しそうな箇所を目視確認した
  - [x] 「世帯員あなた・配偶者・親」に「高校、大学、専門学校、職業訓練学校等の学生ですか？」画面が表示されること
  - [x] 各ステータスを選択したらhouseholdステートが更新されること
  - [x] 各ステータスを選択し/result画面でエラーが出ないこと
  - [x] 各ステータスを選択して次の画面に遷移し、そこから戻った時に選択したボタンが青色に塗り潰されていること
  - [x] chrome dev toolのコンソール画面に追加したコンポーネントのwarningやerrorが出力されていないこと

※ Chromeブラウザ / iPhoneSEサイズで確認しました

<img width="372" src="https://github.com/user-attachments/assets/5c4ddeb0-dbc7-4b70-a076-539be4e58a9c" /> 
<img width="372" height="666" alt="image" src="https://github.com/user-attachments/assets/5b310b5f-b274-40dd-9ff2-649ad8f087ae" />
<img width="372" src="https://github.com/user-attachments/assets/bf2a80ad-2304-40cb-bb2f-430d4b6319ed" />

