### PR TITLE
「前へ」ボタンが目立たないように色変更

### DIFF
--- a/dashboard/src/components/forms/templates/question.tsx
+++ b/dashboard/src/components/forms/templates/question.tsx
@@ -80,9 +80,9 @@ export const Question = (props: {
           borderRadius="xl"
           height="2em"
           width="100%"
-          bg="cyan.600"
-          color="white"
-          _hover={{ bg: 'cyan.700' }}
+          bg="white"
+          color="cyan.600"
+          _hover={{ bg: 'cyan.700', color: 'white' }}
           onClick={props.backOnClick}
         >
           前へ


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は 一問一答画面の `前へ` ボタン を修正する
  - そのために ボタンを目立たない白色に変更した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した

<img width="827" height="479" alt="image" src="https://github.com/user-attachments/assets/1874680c-fd70-4c6f-84ee-09027148598d" />

クリック時

<img width="823" height="494" alt="image" src="https://github.com/user-attachments/assets/a4b6db4c-2281-453b-a619-8860552a9191" />


close #418