### PR TITLE
かんたん見積もりの子どもの年齢でクラッシュする不具合を修正

### DIFF
--- a/dashboard/src/components/forms/questions/simpleChildAgeQuestion.tsx
+++ b/dashboard/src/components/forms/questions/simpleChildAgeQuestion.tsx
@@ -1,0 +1,23 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import {
+  householdAtom,
+  nextQuestionKeyAtom,
+  questionKeyAtom,
+} from '../../../state';
+import { ChildrenAgeQuestion } from '../templates/childrenAgeQuestion';
+import { useEffect } from 'react';
+
+export const SimpleChildAgeQuestion = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  const household = useRecoilValue(householdAtom);
+  const [nextQuestionKey, setNextQuestionKey] =
+    useRecoilState(nextQuestionKeyAtom);
+  const personName = `子ども${questionKey.personNum}`;
+
+  useEffect(() => {
+    // この質問が最後
+    setNextQuestionKey(null);
+  }, [household]);
+
+  return <ChildrenAgeQuestion personName={personName} />;
+};

--- a/dashboard/src/components/forms/simpleQuestionList.tsx
+++ b/dashboard/src/components/forms/simpleQuestionList.tsx
@@ -5,6 +5,7 @@ import { SpouseIncome } from './questions/spouseIncome';
 import { SimpleChildrenNumQuestion } from './questions/simpleChildrenNumQuestion';
 import { ChildAgeQuestion } from './questions/childAgeQuestion';
 import { SimpleSpouseExistsQuestion } from './questions/simpleSpouseExistsQuestion';
+import { SimpleChildAgeQuestion } from './questions/simpleChildAgeQuestion';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -36,7 +37,7 @@ const questions = {
   子ども: [
     {
       title: '年齢',
-      component: <ChildAgeQuestion key={0} />,
+      component: <SimpleChildAgeQuestion key={0} />,
     },
   ],
   親: [],


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は かんたん見積もりの子どもの年齢入力後にクラッシュする不具合を を修正する
  - そのために ページ遷移先判定方法 を変更した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
  - かんたん見積もりでこども1人→年齢 1歳で `次へ` で見積もり結果が出る
