### PR TITLE
一問一答のレイアウトをスマホに最適化

### DIFF
--- a/dashboard/src/components/TermsModal.tsx
+++ b/dashboard/src/components/TermsModal.tsx
@@ -162,7 +162,7 @@ function TermsModal({
                 fontSize={configData.style.subTitleFontSize}
                 bg="cyan.600"
                 color="white"
-                p="1em"
+                p="1.5em"
                 borderRadius="xl"
                 width="100%"
                 isDisabled={!agreedToTerms}

--- a/dashboard/src/components/forms/calculationLabel.tsx
+++ b/dashboard/src/components/forms/calculationLabel.tsx
@@ -12,7 +12,7 @@ export const CalculationLabel = ({
       variant="outline"
       size="lg"
       colorScheme={colour}
-      sx={{ height: '32px' }}
+      sx={{ height: '48px' }}
     >
       {text}
     </Tag>

--- a/dashboard/src/components/forms/questions/addressQuestion.tsx
+++ b/dashboard/src/components/forms/questions/addressQuestion.tsx
@@ -7,6 +7,8 @@ import {
   FormControl,
   FormLabel,
   Center,
+  Text,
+  VStack,
 } from '@chakra-ui/react';
 
 import configData from '../../../config/app_config.json';
@@ -114,56 +116,59 @@ export const AddressQuestion = () => {
   }, [navigationType]);
 
   return (
-    <>
+    <VStack>
       <ErrorMessage />
-
       <FormControl>
-        <FormLabel
-          fontSize={configData.style.itemFontSize}
-          fontWeight="Regular"
-        >
+        <FormLabel fontSize={configData.style.itemFontSize}>
           <Center>
             <HStack>
-              <Box fontSize={configData.style.itemFontSize}>
+              <Box
+                fontSize={configData.style.subTitleFontSize}
+                textAlign="center"
+              >
                 寝泊まりしている地域
               </Box>
             </HStack>
           </Center>
         </FormLabel>
 
-        <HStack mb={4}>
-          <Select
-            data-testid="select-prefecture"
-            value={selectedPrefecture}
-            onChange={onPrefectureChange}
-            fontSize={configData.style.itemFontSize}
-            width={configData.style.selectPrefectureSize}
-            placeholder="都道府県"
-          >
-            {prefectureArray.map((item) => (
-              <option value={item} key={item}>
-                {item}
-              </option>
-            ))}
-          </Select>
-
-          <Select
-            data-testid="select-city"
-            value={selectedMunicipality}
-            onChange={onMunicipalityChange}
-            fontSize={configData.style.itemFontSize}
-            width={configData.style.selectPrefectureSize}
-            placeholder="市区町村"
-          >
-            {selectedPrefecture &&
-              pmObj[selectedPrefecture].map((item) => (
+        <Center>
+          <HStack mt={8} mb={8}>
+            <Select
+              height="3.5em"
+              data-testid="select-prefecture"
+              value={selectedPrefecture}
+              onChange={onPrefectureChange}
+              fontSize={configData.style.itemFontSize}
+              width={configData.style.selectPrefectureSize}
+              placeholder="都道府県"
+            >
+              {prefectureArray.map((item) => (
                 <option value={item} key={item}>
                   {item}
                 </option>
               ))}
-          </Select>
-        </HStack>
+            </Select>
+
+            <Select
+              height="3.5em"
+              data-testid="select-city"
+              value={selectedMunicipality}
+              onChange={onMunicipalityChange}
+              fontSize={configData.style.itemFontSize}
+              width={configData.style.selectPrefectureSize}
+              placeholder="市区町村"
+            >
+              {selectedPrefecture &&
+                pmObj[selectedPrefecture].map((item) => (
+                  <option value={item} key={item}>
+                    {item}
+                  </option>
+                ))}
+            </Select>
+          </HStack>
+        </Center>
       </FormControl>
-    </>
+    </VStack>
   );
 };

--- a/dashboard/src/components/forms/templates/ageQuestion.tsx
+++ b/dashboard/src/components/forms/templates/ageQuestion.tsx
@@ -7,6 +7,7 @@ import {
   FormLabel,
   Input,
   Center,
+  VStack,
 } from '@chakra-ui/react';
 
 import configData from '../../../config/app_config.json';
@@ -105,42 +106,46 @@ export const AgeQuestion = ({ personName }: { personName: string }) => {
   }, [navigationType, age]);
 
   return (
-    <>
+    <VStack flex={1}>
       <ErrorMessage />
       <FormControl>
-        <FormLabel fontSize={configData.style.itemFontSize}>
+        <FormLabel fontSize={configData.style.subTitleFontSize}>
           <Center>
-            <Box>年齢</Box>
+            <Box textAlign="center">年齢</Box>
           </Center>
         </FormLabel>
 
-        <HStack mb={4}>
-          <Input
-            width="6em"
-            fontSize={configData.style.itemFontSize}
-            type={isMobile ? 'number' : 'text'}
-            value={age}
-            onChange={handleAgeChange}
-            onKeyDown={(event) => {
-              if (event.key === 'ArrowUp') {
-                event.preventDefault();
-                changeAge(Number(age) + 1);
-              }
+        <Center>
+          <HStack mt={8} mb={8}>
+            <Input
+              width="100%"
+              height="3.5em"
+              textAlign="right"
+              fontSize={configData.style.itemFontSize}
+              type={isMobile ? 'number' : 'text'}
+              value={age}
+              onChange={handleAgeChange}
+              onKeyDown={(event) => {
+                if (event.key === 'ArrowUp') {
+                  event.preventDefault();
+                  changeAge(Number(age) + 1);
+                }
 
-              if (event.key === 'ArrowDown') {
-                event.preventDefault();
                 if (event.key === 'ArrowDown') {
                   event.preventDefault();
-                  const newAge = Math.max(Number(age) - 1, 0);
-                  changeAge(Number(newAge === 0 ? '' : newAge));
+                  if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    const newAge = Math.max(Number(age) - 1, 0);
+                    changeAge(Number(newAge === 0 ? '' : newAge));
+                  }
                 }
-              }
-            }}
-            {...(isMobile && { pattern: '[0-9]*' })}
-          />
-          <Box>歳</Box>
-        </HStack>
+              }}
+              {...(isMobile && { pattern: '[0-9]*' })}
+            />
+            <Box>歳</Box>
+          </HStack>
+        </Center>
       </FormControl>
-    </>
+    </VStack>
   );
 };

--- a/dashboard/src/components/forms/templates/amountOfMoney.tsx
+++ b/dashboard/src/components/forms/templates/amountOfMoney.tsx
@@ -6,6 +6,7 @@ import {
   FormLabel,
   Input,
   Center,
+  VStack,
 } from '@chakra-ui/react';
 
 import configData from '../../../config/app_config.json';
@@ -125,31 +126,35 @@ export const AmountOfMoney = ({
   }, [personName]);
 
   return (
-    <>
+    <VStack flex={1}>
       <ErrorMessage />
       <FormControl>
-        <FormLabel fontSize={configData.style.itemFontSize}>
+        <FormLabel fontSize={configData.style.subTitleFontSize}>
           <Center>
             <HStack>
-              <Box>{title}</Box>
+              <Box textAlign="center">{title}</Box>
             </HStack>
           </Center>
         </FormLabel>
 
-        <HStack mb={4}>
-          <Input
-            data-testid="amount-input"
-            type={isMobile ? 'number' : 'text'}
-            value={shownAmount}
-            onChange={onChange}
-            onKeyDown={onKeyDown}
-            width="10em"
-            fontSize={configData.style.itemFontSize}
-            {...(isMobile && { pattern: '[0-9]*' })}
-          />
-          <Box>万円</Box>
-        </HStack>
+        <Center>
+          <HStack mt={8} mb={8}>
+            <Input
+              height="3.5em"
+              textAlign="right"
+              data-testid="amount-input"
+              type={isMobile ? 'number' : 'text'}
+              value={shownAmount}
+              onChange={onChange}
+              onKeyDown={onKeyDown}
+              width="80%"
+              fontSize={configData.style.itemFontSize}
+              {...(isMobile && { pattern: '[0-9]*' })}
+            />
+            <Box>万円</Box>
+          </HStack>
+        </Center>
       </FormControl>
-    </>
+    </VStack>
   );
 };

--- a/dashboard/src/components/forms/templates/childrenAgeQuestion.tsx
+++ b/dashboard/src/components/forms/templates/childrenAgeQuestion.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Select,
   Center,
+  VStack,
 } from '@chakra-ui/react';
 
 import configData from '../../../config/app_config.json';
@@ -342,14 +343,11 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
   }, [schoolYear, schoolEducationalAuthority]);
 
   return (
-    <>
+    <VStack flex={1}>
       <ErrorMessage />
       <HStack>
         <FormControl paddingRight={4}>
-          <FormLabel
-            fontSize={configData.style.itemFontSize}
-            fontWeight="Regular"
-          >
+          <FormLabel fontSize={configData.style.subTitleFontSize}>
             <Center>
               <HStack>
                 <Box>年齢</Box>
@@ -357,9 +355,10 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
             </Center>
           </FormLabel>
 
-          <HStack mb={4}>
+          <HStack mt={8} mb={8}>
             <Input
-              width="4em"
+              width="3em"
+              height="3.5em"
               fontSize={configData.style.itemFontSize}
               type={isMobile ? 'number' : 'text'}
               value={age}
@@ -385,18 +384,22 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
           </HStack>
         </FormControl>
         <FormControl>
-          <FormLabel
-            fontSize={configData.style.itemFontSize}
-            fontWeight="Regular"
-          >
-            <HStack>
-              <Box>学年</Box>
-            </HStack>
+          <FormLabel fontSize={configData.style.subTitleFontSize}>
+            <Center>
+              <HStack>
+                <Box>学年</Box>
+              </HStack>
+            </Center>
           </FormLabel>
 
-          <HStack mb={4}>
+          <HStack mt={8} mb={8}>
             <Select
-              width="9em"
+              width={
+                ignoreSchoolYear.includes(schoolEducationalAuthority)
+                  ? '11em'
+                  : '7em'
+              }
+              height="3.5em"
               value={schoolEducationalAuthority}
               placeholder="学校教育機関"
               fontSize={configData.style.itemFontSize}
@@ -431,7 +434,8 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
               typeof schoolEducationalAuthority !== 'undefined' &&
               schoolEducationalAuthority !== '' && (
                 <Input
-                  width="6em"
+                  width="3em"
+                  height="3.5em"
                   fontSize={configData.style.itemFontSize}
                   type={isMobile ? 'number' : 'text'}
                   value={schoolYear}
@@ -439,11 +443,10 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
                   {...(isMobile && { pattern: '[0-9]*' })}
                 />
               )}
-            {/* NOTE:  */}
             {suffix && <Box whiteSpace="nowrap">{suffix}</Box>}
           </HStack>
         </FormControl>
       </HStack>
-    </>
+    </VStack>
   );
 };

--- a/dashboard/src/components/forms/templates/multipleSelectionQuestion.tsx
+++ b/dashboard/src/components/forms/templates/multipleSelectionQuestion.tsx
@@ -72,10 +72,11 @@ export const MultipleSelectionQuestion = ({
     key: number;
   }) => (
     <Button
+      mb={2}
       key={key}
       variant="outline"
       borderRadius="xl"
-      height="2.5em"
+      height="3.5em"
       width="100%"
       bg={cond() ? 'cyan.600' : 'white'}
       borderColor={cond() ? 'cyan.900' : 'black'}
@@ -109,18 +110,18 @@ export const MultipleSelectionQuestion = ({
   return (
     <>
       <FormControl>
-        <FormLabel
-          fontSize={configData.style.itemFontSize}
-          fontWeight="Regular"
-        >
-          <Center>
-            <Box fontSize={configData.style.itemFontSize}>
+        <FormLabel fontSize={configData.style.itemFontSize}>
+          <Center mb={4}>
+            <Box
+              fontSize={configData.style.subTitleFontSize}
+              textAlign="center"
+            >
               {title + '（複数選択）'}
             </Box>
           </Center>
         </FormLabel>
 
-        <VStack mb={4}>
+        <VStack mt={8} mb={8}>
           {selections.map((e, index) =>
             btn({
               cond: () => selectionsState[e.selection],

--- a/dashboard/src/components/forms/templates/personNumQuestion.tsx
+++ b/dashboard/src/components/forms/templates/personNumQuestion.tsx
@@ -10,6 +10,7 @@ import {
   Spacer,
   SimpleGrid,
   Center,
+  VStack,
 } from '@chakra-ui/react';
 
 import configData from '../../../config/app_config.json';
@@ -156,10 +157,11 @@ export const PersonNumQuestion = ({
     onClick: () => void;
   }) => (
     <Button
+      mb={2}
       variant="outline"
       borderRadius="xl"
-      height="2.5em"
-      width="12em"
+      height="3.5em"
+      width="100%"
       bg={cond() ? 'cyan.600' : 'white'}
       borderColor={cond() ? 'cyan.900' : 'black'}
       color={cond() ? 'white' : 'black'}
@@ -182,19 +184,21 @@ export const PersonNumQuestion = ({
   );
 
   return (
-    <>
+    <VStack flex={1}>
       <ErrorMessage />
       <FormControl>
-        <FormLabel
-          fontSize={configData.style.itemFontSize}
-          fontWeight="Regular"
-        >
-          <Center>
-            <Box fontSize={configData.style.itemFontSize}>{title}</Box>
+        <FormLabel fontSize={configData.style.itemFontSize}>
+          <Center mb={4}>
+            <Box
+              fontSize={configData.style.subTitleFontSize}
+              textAlign="center"
+            >
+              {title}
+            </Box>
           </Center>
         </FormLabel>
 
-        <SimpleGrid columns={2} rowGap={1} columnGap={6}>
+        <SimpleGrid columns={2} rowGap={1} columnGap={6} mt={8} mb={8}>
           {btn({
             cond: () => boolState === true,
             state: true,
@@ -208,6 +212,7 @@ export const PersonNumQuestion = ({
           <FormControl>
             <HStack>
               <Input
+                height="3.5em"
                 type={isMobile ? 'number' : 'text'}
                 value={shownPersonNum}
                 onChange={onChange}
@@ -229,7 +234,7 @@ export const PersonNumQuestion = ({
                     updatePersonInfo(newPersonNum);
                   }
                 }}
-                width="6em"
+                width="100%"
                 ref={inputEl}
                 {...(isMobile && { pattern: '[0-9]*' })}
               />
@@ -250,6 +255,6 @@ export const PersonNumQuestion = ({
           <Spacer />
         </SimpleGrid>
       </FormControl>
-    </>
+    </VStack>
   );
 };

--- a/dashboard/src/components/forms/templates/question.tsx
+++ b/dashboard/src/components/forms/templates/question.tsx
@@ -36,7 +36,7 @@ export const Question = (props: {
       />
       <Flex w="100%" justifyContent="space-around" alignItems="center">
         <Link href="/" ml={0} paddingLeft="1.5em">
-          <Icon as={FaHome} boxSize="2em" color="cyan.600" />
+          <Icon as={FaHome} boxSize="3em" color="cyan.600" />
         </Link>
         <Box ml="auto">
           <CalculationLabel
@@ -62,14 +62,14 @@ export const Question = (props: {
         fontSize={configData.style.subTitleFontSize}
         fontWeight="medium"
         mt={2}
-        mb={2}
+        mb={4}
       >
         {props.title}
       </Center>
 
-      <Box bg="white" borderRadius="xl" p={4} mb={4} ml={4} mr={4}>
+      <Box bg="white" borderRadius="xl" p={4} m={4}>
         <Center fontSize={configData.style.questionFormFontSize} mb={2}>
-          <form>{props.children}</form>
+          {props.children}
         </Center>
       </Box>
 
@@ -78,7 +78,7 @@ export const Question = (props: {
           fontSize={configData.style.subTitleFontSize}
           style={{ marginRight: '10%' }}
           borderRadius="xl"
-          height="2em"
+          height="3.5em"
           width="100%"
           bg="white"
           color="cyan.600"
@@ -90,7 +90,7 @@ export const Question = (props: {
         <Button
           fontSize={configData.style.subTitleFontSize}
           borderRadius="xl"
-          height="2em"
+          height="3.5em"
           width="100%"
           bg="cyan.600"
           color="white"

--- a/dashboard/src/components/forms/templates/questionDescription.tsx
+++ b/dashboard/src/components/forms/templates/questionDescription.tsx
@@ -2,6 +2,7 @@ import { Text } from '@chakra-ui/react';
 import { questionValidatedAtom } from '../../../state';
 import { useRecoilState } from 'recoil';
 import { useEffect } from 'react';
+import configData from '../../../config/app_config.json';
 
 export const QuestionDescription = ({
   description,
@@ -17,5 +18,9 @@ export const QuestionDescription = ({
     setQuestionValidated(true);
   }, []);
 
-  return <Text>{description}</Text>;
+  return (
+    <Text fontSize={configData.style.subTitleFontSize} textAlign="center">
+      {description}
+    </Text>
+  );
 };

--- a/dashboard/src/components/forms/templates/selectionQuestion.tsx
+++ b/dashboard/src/components/forms/templates/selectionQuestion.tsx
@@ -56,10 +56,11 @@ export const SelectionQuestion = ({
     key: number;
   }) => (
     <Button
+      mb={2}
       key={key}
       variant="outline"
       borderRadius="xl"
-      height="2.5em"
+      height="3.5em"
       width="100%"
       bg={cond() ? 'cyan.600' : 'white'}
       borderColor={cond() ? 'cyan.900' : 'black'}
@@ -82,19 +83,21 @@ export const SelectionQuestion = ({
   );
 
   return (
-    <>
+    <VStack flex={1}>
       <ErrorMessage />
       <FormControl>
-        <FormLabel
-          fontSize={configData.style.itemFontSize}
-          fontWeight="Regular"
-        >
-          <Center>
-            <Box fontSize={configData.style.itemFontSize}>{title}</Box>
+        <FormLabel fontSize={configData.style.itemFontSize}>
+          <Center mb={4}>
+            <Box
+              fontSize={configData.style.subTitleFontSize}
+              textAlign="center"
+            >
+              {title}
+            </Box>
           </Center>
         </FormLabel>
 
-        <VStack mb={4}>
+        <VStack mt={8} mb={8}>
           {selections.map((e, index) =>
             btn({
               cond: () => selectionState === e.selection,
@@ -105,6 +108,6 @@ export const SelectionQuestion = ({
           )}
         </VStack>
       </FormControl>
-    </>
+    </VStack>
   );
 };

--- a/dashboard/src/components/forms/templates/yesNoQuestion.tsx
+++ b/dashboard/src/components/forms/templates/yesNoQuestion.tsx
@@ -60,9 +60,10 @@ export const YesNoQuestion = ({
     title: string;
   }) => (
     <Button
+      mb={2}
       variant="outline"
       borderRadius="xl"
-      height="2.5em"
+      height="3.5em"
       width="100%"
       bg={cond() ? 'cyan.600' : 'white'}
       borderColor={cond() ? 'cyan.900' : 'black'}
@@ -83,23 +84,22 @@ export const YesNoQuestion = ({
   );
 
   return (
-    <>
+    <VStack flex={1}>
       <ErrorMessage />
-
       <FormControl>
-        <FormLabel
-          fontSize={configData.style.itemFontSize}
-          fontWeight="Regular"
-        >
-          <Center>
-            <Box fontSize={configData.style.itemFontSize}>{title}</Box>
+        <FormLabel fontSize={configData.style.itemFontSize}>
+          <Center mb={4}>
+            <Box
+              fontSize={configData.style.subTitleFontSize}
+              textAlign="center"
+            >
+              {title}
+            </Box>
           </Center>
         </FormLabel>
-        <Box mt={2} mb={4}>
-          {children}
-        </Box>
+        <Box mb={2}>{children}</Box>
 
-        <VStack mb={4}>
+        <VStack mt={8} mb={8}>
           {btn({
             cond: () => boolState === true,
             state: true,
@@ -112,6 +112,6 @@ export const YesNoQuestion = ({
           })}
         </VStack>
       </FormControl>
-    </>
+    </VStack>
   );
 };

--- a/dashboard/src/components/forms/validation/ErrorMessage.tsx
+++ b/dashboard/src/components/forms/validation/ErrorMessage.tsx
@@ -16,10 +16,11 @@ export const ErrorMessage = () => {
           color="red.800"
           border="1px"
           borderColor="red.200"
-          borderRadius="lg"
+          borderRadius="xl"
           fontSize="md"
+          width="100%"
           p={1}
-          mt={5}
+          mt={1}
           mb={1}
         >
           入力必須項目です


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は 一問一答レイアウトをスマホで使いやすいよう修正する
  - そのためにボタンの高さ を変更した
  - そのために文字の大きさを変更した
  - そのためにボタンどうしの感覚を変更した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
  - ロジック変更なし、要素の大きさと配置のみ修正

各テンプレートのレイアウト

規約の同意
<img height="480" alt="image" src="https://github.com/user-attachments/assets/df64d742-d287-49da-a498-40cf8662187a" />

寝泊まりしている地域
<img height="480" alt="image" src="https://github.com/user-attachments/assets/76e51f5d-388c-4158-b8d2-a4efa7c81184" />

年齢
<img height="480" alt="image" src="https://github.com/user-attachments/assets/70718061-a223-4ed1-940b-b0871b689f43" />

金額
<img height="480" alt="image" src="https://github.com/user-attachments/assets/7d94945a-862d-411c-b9e8-95e16c479db7" />

yesno
<img height="480" alt="image" src="https://github.com/user-attachments/assets/6f30586f-96de-4f4f-9547-1748fadc0c09" />

選択
<img height="480" alt="image" src="https://github.com/user-attachments/assets/89270d6b-31b1-47cc-95a3-4a17f4daaf23" />

選択（複数）
<img height="480" alt="image" src="https://github.com/user-attachments/assets/ae5bd52c-e111-4085-be67-a84fac199167" />

人数
<img height="480" alt="image" src="https://github.com/user-attachments/assets/fa8baeba-77a9-4a46-a4ce-1a0ce5aaf358" />

子どもの年齢
<img height="480" alt="image" src="https://github.com/user-attachments/assets/113f31e1-503f-42b7-ade7-f4db907452c3" />

<img height="480" alt="image" src="https://github.com/user-attachments/assets/155637a4-a1c7-4e70-8d4d-2db8d04ff920" />

バリエーションエラーのメッセージ
<img height="480" alt="image" src="https://github.com/user-attachments/assets/6e0093f4-5c07-4dff-ae53-2153366247f0" />



