### PR TITLE
質問の遷移でクラッシュしないように修正

### DIFF
--- a/dashboard/src/components/forms/questions/parentHepatitisC.tsx
+++ b/dashboard/src/components/forms/questions/parentHepatitisC.tsx
@@ -14,7 +14,7 @@ export const ParentHepatitisC = () => {
   const noOnClick = () => {
     // 仕事関連の質問をスキップ
     setNextQuestionKey({
-      person: '子ども',
+      person: '親',
       personNum: questionKey.personNum,
       title: '腎不全',
     });

--- a/dashboard/src/components/forms/questions/simpleSpouseExistsQuestion.tsx
+++ b/dashboard/src/components/forms/questions/simpleSpouseExistsQuestion.tsx
@@ -1,5 +1,4 @@
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { useEffect } from 'react';
 import { YesNoQuestion } from '../templates/yesNoQuestion';
 import {
   currentDateAtom,
@@ -27,6 +26,9 @@ export const SimpleSpouseExistsQuestion = () => {
     setHousehold(newHousehold);
 
     const newFrontendHousehold = { ...frontendHousehold };
+    if (!newFrontendHousehold.世帯員['配偶者']) {
+      newFrontendHousehold.世帯員['配偶者'] = {};
+    }
     newFrontendHousehold.世帯['配偶者がいる'] = true;
     setFrontendHousehold(newFrontendHousehold);
 
@@ -47,8 +49,9 @@ export const SimpleSpouseExistsQuestion = () => {
         [currentDate]: false,
       };
     }
-    setHousehold(household);
+    setHousehold(newHousehold);
 
+    // frontendHouseholdは入力した選択肢を保持するため、配偶者がいないと訂正した場合も 世帯員['配偶者'] の削除は不要
     const newFrontendHousehold = { ...frontendHousehold };
     newFrontendHousehold.世帯['配偶者がいる'] = false;
     setFrontendHousehold(newFrontendHousehold);
@@ -60,31 +63,6 @@ export const SimpleSpouseExistsQuestion = () => {
       title: '子どもの人数',
     });
   };
-
-  const isAlreadySelected = (frontendHousehold: any): boolean | null => {
-    if (frontendHousehold.世帯['配偶者がいる'] != null) {
-      return frontendHousehold.世帯['配偶者がいる'];
-    }
-    return null;
-  };
-
-  useEffect(() => {
-    if (isAlreadySelected(frontendHousehold) != null) {
-      if (isAlreadySelected(frontendHousehold)) {
-        setNextQuestionKey({
-          person: '配偶者',
-          personNum: 0,
-          title: '年収',
-        });
-      } else {
-        setNextQuestionKey({
-          person: 'あなた',
-          personNum: 0,
-          title: '子どもの人数',
-        });
-      }
-    }
-  }, []);
 
   return (
     <YesNoQuestion

--- a/dashboard/src/components/homeButton.tsx
+++ b/dashboard/src/components/homeButton.tsx
@@ -1,8 +1,37 @@
 import { Flex, Icon } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
 import { FaHome } from 'react-icons/fa';
+import {
+  defaultNextQuestionKeyAtom,
+  nextQuestionKeyAtom,
+  questionKeyAtom,
+  questionKeyHistoryAtom,
+  resetQuestionKeys,
+} from '../state';
+import { useRecoilState } from 'recoil';
 
 export const HomeButton = () => {
+  const [questionKey, setQuestionKey] = useRecoilState(questionKeyAtom);
+  const [nextQuestionKey, setNextQuestionKey] =
+    useRecoilState(nextQuestionKeyAtom);
+  const [defaultNextQuestionKey, setDefaultNextQuestionKey] = useRecoilState(
+    defaultNextQuestionKeyAtom
+  );
+  const [questionKeyHistory, setQuestionKeyHistory] = useRecoilState(
+    questionKeyHistoryAtom
+  );
+
+  const onClick = () => {
+    // 質問の1問目に戻る
+    // (戻さないと別の見積もりモードへ移った際に想定外の設問から始まってしまうため)
+    resetQuestionKeys({
+      setQuestionKey,
+      setNextQuestionKey,
+      setDefaultNextQuestionKey,
+      setQuestionKeyHistory,
+    });
+  };
+
   return (
     <Flex w="90%" justifyContent="left" marginTop="0.5em">
       <RouterLink to="/">
@@ -12,6 +41,7 @@ export const HomeButton = () => {
           justifyContent="left"
           boxSize="4em"
           color="cyan.900"
+          onClick={onClick}
         />
       </RouterLink>
     </Flex>

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -9,7 +9,15 @@ import { useCalculate } from '../../hooks/calculate';
 import { Benefit } from './benefit';
 import { Loan } from './loan';
 import { CalculationLabel } from '../forms/calculationLabel';
-import { frontendHouseholdAtom, householdAtom } from '../../state';
+import {
+  defaultNextQuestionKeyAtom,
+  frontendHouseholdAtom,
+  householdAtom,
+  nextQuestionKeyAtom,
+  questionKeyAtom,
+  questionKeyHistoryAtom,
+  resetQuestionKeys,
+} from '../../state';
 import { useRecoilState } from 'recoil';
 import shortLink, {
   inflate,
@@ -47,6 +55,27 @@ export const Result = () => {
         isDisasterCalculation: isDisasterCalculation,
         redirect: '/',
       },
+    });
+  };
+
+  const [questionKey, setQuestionKey] = useRecoilState(questionKeyAtom);
+  const [nextQuestionKey, setNextQuestionKey] =
+    useRecoilState(nextQuestionKeyAtom);
+  const [defaultNextQuestionKey, setDefaultNextQuestionKey] = useRecoilState(
+    defaultNextQuestionKeyAtom
+  );
+  const [questionKeyHistory, setQuestionKeyHistory] = useRecoilState(
+    questionKeyHistoryAtom
+  );
+
+  const detailedCalculationonClick = () => {
+    // 質問の1問目に戻る
+    // (戻さないと別の見積もりモードへ移った際に想定外の設問から始まってしまうため)
+    resetQuestionKeys({
+      setQuestionKey,
+      setNextQuestionKey,
+      setDefaultNextQuestionKey,
+      setQuestionKeyHistory,
     });
   };
 
@@ -335,6 +364,7 @@ export const Result = () => {
                     bg="blue.500"
                     color="white"
                     _hover={{ bg: 'blue.600' }}
+                    onClick={detailedCalculationonClick}
                   >
                     {configData.calculationForm.detailedCalculation}
                   </Button>

--- a/dashboard/src/components/top/topPage.tsx
+++ b/dashboard/src/components/top/topPage.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import configData from '../../config/app_config.json';
 import personIcon1 from '../../assets/top/person_icon1.png';
 import personIcon2 from '../../assets/top/person_icon2.png';
@@ -55,10 +55,10 @@ export function TopPage() {
               textAlign="center"
             >
               {configData.topPage.title.map((line, i) => (
-                <>
-                  <span key={i}>{line}</span>
+                <Fragment key={i}>
+                  <span>{line}</span>
                   <NarrowBr />
-                </>
+                </Fragment>
               ))}
             </Text>
           </Center>

--- a/dashboard/src/state.ts
+++ b/dashboard/src/state.ts
@@ -244,7 +244,7 @@ export const householdAtom = atom<any>({
 
 export type FrontendHousehold = {
   世帯員: { [key: string]: { [key: string]: any } };
-  世帯: { [key: string]: boolean | number };
+  世帯: { [key: string]: boolean | number | string };
   困りごと: { [key: string]: boolean };
   制度: { [key: string]: boolean };
 };

--- a/dashboard/src/state.ts
+++ b/dashboard/src/state.ts
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atom, SetterOrUpdater } from 'recoil';
 import { QuestionKey } from './question';
 
 const currentDate = `${new Date().getFullYear()}-${(new Date().getMonth() + 1)
@@ -48,6 +48,27 @@ export const questionKeyHistoryAtom = atom<QuestionKey[]>({
   key: 'questionKeyHistoryAtom',
   default: [],
 });
+
+export const resetQuestionKeys = ({
+  setQuestionKey,
+  setNextQuestionKey,
+  setDefaultNextQuestionKey,
+  setQuestionKeyHistory,
+}: {
+  setQuestionKey: SetterOrUpdater<QuestionKey>;
+  setNextQuestionKey: SetterOrUpdater<QuestionKey | null>;
+  setDefaultNextQuestionKey: SetterOrUpdater<QuestionKey | null>;
+  setQuestionKeyHistory: SetterOrUpdater<QuestionKey[]>;
+}) => {
+  setQuestionKey({
+    person: 'あなた',
+    personNum: 0,
+    title: '住んでいる場所',
+  });
+  setNextQuestionKey(null);
+  setDefaultNextQuestionKey(null);
+  setQuestionKeyHistory([]);
+};
 
 export const householdAtom = atom<any>({
   key: 'householdAtom',


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は フロントエンドの質問遷移時に発生するクラッシュ を修正する
  - そのために かんたん見積もりの配偶者に関する質問の遷移先 を修正した (#428)
  - そのために 親の感染症に関する質問の遷移先 を修正した (#433)
  - そのために くわしく見積もりからかんたん見積もりに移動した際の質問の遷移先 を修正した (#429)
  - そのために くわしく見積もりからかんたん見積もりに移動した際の住んでいる場所のバリデーションチェックを修正した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
  - かんたん見積もりの質問「配偶者がいますか」→「はい」でエラーが発生しない (#428)
  - くわしく見積もりの親の質問「C型肝炎に感染していますか？」→「いいえ」でエラーが発生しない (#433)
  - くわしく見積もりで住んでいる場所を回答→「次へ」→ホームへ戻る→かんたん見積もりでエラーが発生しない (#429)
  - くわしく見積もりで住んでいる場所を回答→「次へ」→ホームへ戻る→かんたん見積もりでバリエーションエラーが発生しない
