### PR TITLE
血友病の質問で見積もり結果がクラッシュする不具合を修正

### DIFF
--- a/dashboard/src/components/forms/questions/healthCondition.tsx
+++ b/dashboard/src/components/forms/questions/healthCondition.tsx
@@ -1,5 +1,10 @@
-import { useRecoilState } from 'recoil';
-import { frontendHouseholdAtom } from '../../../state';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import {
+  currentDateAtom,
+  frontendHouseholdAtom,
+  householdAtom,
+  questionKeyAtom,
+} from '../../../state';
 import { MultipleSelectionQuestion } from '../templates/multipleSelectionQuestion';
 import { useEffect } from 'react';
 
@@ -10,9 +15,22 @@ export const HealthCondition = ({
   personName: string;
   updateNextQuestionKey: (frontendHousehold: any) => void;
 }) => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  const currentDate = useRecoilValue(currentDateAtom);
+  const [household, setHousehold] = useRecoilState(householdAtom);
   const [frontendHousehold, setFrontendHousehold] = useRecoilState(
     frontendHouseholdAtom
   );
+
+  // 感染症関連の質問がスキップされた場合も値が欠けないよう、デフォルト値のfalseを挿入
+  // （当てはまる場合は、後の当該質問でtrueに上書きされる）
+  useEffect(() => {
+    const newHousehold = { ...household };
+    newHousehold.世帯員[personName].HIV感染者である = {
+      [currentDate]: false,
+    };
+    setHousehold({ ...newHousehold });
+  }, [questionKey]);
 
   const selectionValues = ['病気がある', 'けがをしている', '障害がある'];
 


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は 血友病に該当する場合に見積もり結果画面でクラッシュ（下図）してしまう不具合 を修正する
  - そのために質問 `病気やけが、障害はありますか？（複数選択可）` に世帯情報のデフォルト値を追加した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した

クラッシュの条件（before）
  - くわしく見積もり
  - 病気、障害、けが→病気があるのみ選択
  - 感染症にかかっていますか？→いいえ
  - 先天性の血液凝固因子異常症（血友病等）ですか？→はい
  - 血液凝固因子異常症のうち、当てはまるものはどれですか？（複数選択可）→血友病A

<img width="1304" height="497" alt="image" src="https://github.com/user-attachments/assets/771c5e7e-87b1-4f06-9c91-0c7da4cda28c" />

(after)見積もり結果の表示を確認

