### PR TITLE
災害関連支援の子供の年齢でクラッシュする不具合を修正

### DIFF
--- a/dashboard/src/components/forms/disasterQuestionList.tsx
+++ b/dashboard/src/components/forms/disasterQuestionList.tsx
@@ -24,6 +24,7 @@ import { ParentDisasterInjuryQuestion } from './questions/parentDisasterInjuryQu
 import { SimpleSpouseExistsQuestion } from './questions/simpleSpouseExistsQuestion';
 import { DisasterParentNumQuestion } from './questions/disasterParentNumQuestion';
 import { ParentIncome } from './questions/parentIncome';
+import { DisasterChildAgeQuestion } from './questions/disasterChildAgeQuestion';
 
 // NOTE: プログレスバーの計算のために設問に順序関係を定義する必要があるため、objectではなくarrayを使用
 // HACK: componentをarray内に定義する際にkeyが必要なため定義している
@@ -99,7 +100,7 @@ const questions = {
   子ども: [
     {
       title: '年齢',
-      component: <ChildAgeQuestion key={0} />,
+      component: <DisasterChildAgeQuestion key={0} />,
     },
     {
       title: '災害による負傷',

--- a/dashboard/src/components/forms/questions/disasterChildAgeQuestion.tsx
+++ b/dashboard/src/components/forms/questions/disasterChildAgeQuestion.tsx
@@ -1,0 +1,15 @@
+import { useRecoilState, useRecoilValue } from 'recoil';
+import {
+  householdAtom,
+  nextQuestionKeyAtom,
+  questionKeyAtom,
+} from '../../../state';
+import { ChildrenAgeQuestion } from '../templates/childrenAgeQuestion';
+
+export const DisasterChildAgeQuestion = () => {
+  const questionKey = useRecoilValue(questionKeyAtom);
+  useRecoilState(nextQuestionKeyAtom);
+  const personName = `子ども${questionKey.personNum}`;
+
+  return <ChildrenAgeQuestion personName={personName} />;
+};


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は 災害関連支援見積もりの子どもの年齢でクラッシュする不具合 を修正する
  - そのために 子どもの年齢の質問遷移先 を変更した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
