### PR TITLE
上部進捗ゲージの視覚的調整を実装し、進み具合を改善

### DIFF
--- a/dashboard/src/components/forms/questionList.tsx
+++ b/dashboard/src/components/forms/questionList.tsx
@@ -275,10 +275,51 @@ export const QuestionList = ({
     : questionKey.person;
   const [progress, maxProgress] = questionProgress(questions, questionKey);
 
+  type Checkpoint = { logicalEnd: number; visualEnd: number };
+
+  /**
+   * 進捗を視覚的調整するための関数
+   * @param currentProgress 現在の進捗
+   * @param currentMax 最大進捗
+   * @param cps チェックポイント（どこまで進んだら、どの割合で表示するか）
+   * @returns 視覚的調整後の進捗
+   */
+  const mapProgress = (
+    currentProgress: number,
+    currentMax: number,
+    cps: Checkpoint[]
+  ): number => {
+    if (currentMax <= 0) return 0;
+    if (currentProgress <= 0) return 0;
+    if (currentProgress >= currentMax) return currentMax;
+
+    const idx = cps.findIndex((cp) => currentProgress <= cp.logicalEnd);
+    if (idx === -1) return currentMax;
+
+    const prevLogical = idx === 0 ? 0 : cps[idx - 1].logicalEnd;
+    const prevVisual = idx === 0 ? 0 : cps[idx - 1].visualEnd;
+    const cp = cps[idx];
+
+    const sectionWidth = cp.logicalEnd - prevLogical || 1;
+    const t = (currentProgress - prevLogical) / sectionWidth; // 0〜1 に正規化
+    const visualRatio = prevVisual + t * (cp.visualEnd - prevVisual);
+    return visualRatio * currentMax;
+  };
+
+  // - 「あなた」の設問をすべて終えた時点で 60%
+  // - 「配偶者」の設問をすべて終えた時点で 80%
+  const selfEnd = questions["あなた"].length;
+  const spouseEnd = questions['あなた'].length + questions['配偶者'].length;
+  const displayProgress = mapProgress(progress, maxProgress, [
+    { logicalEnd: selfEnd, visualEnd: 0.6 },
+    { logicalEnd: spouseEnd, visualEnd: 0.8 },
+    { logicalEnd: maxProgress, visualEnd: 1 },
+  ]);
+
   return (
     <Question
       title={`${personStr}について`}
-      progress={progress}
+      progress={displayProgress}
       maxProgress={maxProgress}
       backOnClick={back}
       nextOnClick={next}

--- a/dashboard/src/components/forms/questionList.tsx
+++ b/dashboard/src/components/forms/questionList.tsx
@@ -308,7 +308,7 @@ export const QuestionList = ({
 
   // - 「あなた」の設問をすべて終えた時点で 60%
   // - 「配偶者」の設問をすべて終えた時点で 80%
-  const selfEnd = questions["あなた"].length;
+  const selfEnd = questions['あなた'].length;
   const spouseEnd = questions['あなた'].length + questions['配偶者'].length;
   const displayProgress = mapProgress(progress, maxProgress, [
     { logicalEnd: selfEnd, visualEnd: 0.6 },


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

### 課題

- 見積もり画面の上部進捗ゲージは、最大質問数を分母にした割合で表示していたため、配偶者がいなかったり子どもが少ないケースでは序盤の進捗が遅く、途中で急に結果が出るように見える問題がありました。
- 子どもの人数が入力されたらそれだけ分母を増やすようなアルゴリズムの変更なども考えられますが、ゲージが後退してしまうため体験がよくありません。
- 進捗計算のアルゴリズムを変えずとも、非線形に進捗を推移させることで視覚的な安心感を表現できると考えました。

### 変更内容

- ユーザーの心理的進捗感を実際の質問数と乖離させないための視覚補正を実装しています。
- この変更では進捗計算を「当人の回答」「配偶者の回答」「その他の回答」の3区画に分割。
  - 当人の回答が終わった段階で 60% に到達するよう調整。
  - 配偶者の回答が終わった段階で 80% に到達するよう調整。
- 区画ごとに進捗の伸び方を制御でき、視覚的に自然な進み具合を実現しました。

### 割合設定の意図

「本人の回答終了で半分以上進んでいたら安心するだろう」という仮説に基づきます。
また、影響が大きく可変な子どもや親の進捗がゲージに与える影響を2割まで抑える意図もあります。

## 動作確認

- [x] くわしく見積もりで想定通りの進みになることを確認しました
- [x] かんたん見積もりで想定外の挙動にならないことを確認しました

## 参考: 変更前後の進捗の進み具合の様子

### 変更前

https://github.com/user-attachments/assets/a98d1b8f-6375-45a5-8774-2d19a9c7aaa4

### 変更後

https://github.com/user-attachments/assets/305f1ff6-33af-4e59-93bf-5c7dcfba9cdf

