### PR TITLE
子どもの年齢表示の残留を防止

### DIFF
--- a/dashboard/src/components/forms/questionList.tsx
+++ b/dashboard/src/components/forms/questionList.tsx
@@ -318,6 +318,10 @@ export const QuestionList = ({
 
   return (
     <Question
+      key={`${questionKey.person}-${questionKey.personNum}-${questionIndex(
+        questions,
+        questionKey
+      )}`}
       title={`${personStr}について`}
       progress={displayProgress}
       maxProgress={maxProgress}

--- a/dashboard/src/components/forms/templates/childrenAgeQuestion.tsx
+++ b/dashboard/src/components/forms/templates/childrenAgeQuestion.tsx
@@ -301,7 +301,11 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
         break;
       }
     }
-  }, [personName, navigationType, household.世帯員[personName].誕生年月日?.ETERNITY]);
+  }, [
+    personName,
+    navigationType,
+    household.世帯員[personName].誕生年月日?.ETERNITY,
+  ]);
 
   // 学校教育機関と学年が変更された時に実行される処理
   useEffect(() => {

--- a/dashboard/src/components/forms/templates/childrenAgeQuestion.tsx
+++ b/dashboard/src/components/forms/templates/childrenAgeQuestion.tsx
@@ -245,6 +245,13 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
   useEffect(() => {
     // 年齢フォームの更新
     const birthdayObj = household.世帯員[personName].誕生年月日;
+    if (!birthdayObj?.ETERNITY) {
+      setAge('');
+      setSchoolYear('');
+      setschoolEducationalAuthority('');
+      setSuffix(undefined);
+      return;
+    }
     if (birthdayObj && birthdayObj.ETERNITY) {
       const birthYear = Number(birthdayObj.ETERNITY.substring(0, 4));
       const birthMonth = Number(birthdayObj.ETERNITY.substring(5, 7));
@@ -294,7 +301,7 @@ export const ChildrenAgeQuestion = ({ personName }: { personName: string }) => {
         break;
       }
     }
-  }, [navigationType, household.世帯員[personName].誕生年月日?.ETERNITY]);
+  }, [personName, navigationType, household.世帯員[personName].誕生年月日?.ETERNITY]);
 
   // 学校教育機関と学年が変更された時に実行される処理
   useEffect(() => {


### PR DESCRIPTION
## Pull request前の確認
- [✓ ] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [✓ ] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要
- この Pull requestは1人目の子どもの年齢が2人目の年齢入力時に表示されないよう修正する
  - そのために 誕生日未入力時に年齢・学年・教育機関をリセットする処理を追加した
  - そのために 子ども切替時に再計算されるよう依存配列にpersonNameを追加した

## 動作確認
- [✓ ] 追加|変更した部分の影響しそうな箇所を目視確認した
