### PR TITLE
見積もり結果にカタリバへのリンクを追加

### DIFF
--- a/dashboard/src/components/result/externalLinks.tsx
+++ b/dashboard/src/components/result/externalLinks.tsx
@@ -1,0 +1,44 @@
+import { Button, Center, Text } from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
+import configData from '../../config/app_config.json';
+
+export const ExternalLinks = ({
+  conditions,
+}: {
+  conditions: { カタリバ: boolean };
+}) => {
+  return (
+    <>
+      {conditions.カタリバ && (
+        <>
+          <Center pr={4} pl={4} pb={2}>
+            <Text color="blue.900">
+              {configData.result.externalLinks.カタリバ.description}
+            </Text>
+          </Center>
+          <Center pr={4} pl={4} pb={4}>
+            <Button
+              as={RouterLink}
+              to={configData.result.externalLinks.カタリバ.url}
+              fontSize={configData.style.subTitleFontSize}
+              borderRadius="xl"
+              height="2em"
+              width="100%"
+              bg={configData.result.externalLinks.カタリバ.color}
+              color="white"
+              // hover時に元の色を薄くする
+              _hover={{
+                bg: `color-mix(in srgb, ${configData.result.externalLinks.カタリバ.color} 60%, #ffffff);`,
+              }}
+              // 新しいタブで開く
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {configData.result.externalLinks.カタリバ.buttonText}
+            </Button>
+          </Center>
+        </>
+      )}
+    </>
+  );
+};

--- a/dashboard/src/components/result/result.tsx
+++ b/dashboard/src/components/result/result.tsx
@@ -32,6 +32,7 @@ import { Applicable } from './applicable';
 import { calculateFrontendHouseHold } from '../calculate/calculate';
 import { NarrowWidth } from '../layout/narrowWidth';
 import { HomeButton } from '../homeButton';
+import { ExternalLinks } from './externalLinks';
 
 const createFileName = (extension: string = '', ...names: string[]) => {
   if (!extension) {
@@ -85,7 +86,6 @@ export const Result = () => {
     frontendHouseholdAtom
   );
   let householdByURL: any;
-  let frontendHouseholdByURL: any;
 
   const [result, calculate] = useCalculate();
 
@@ -327,6 +327,12 @@ export const Result = () => {
                 </Text>
               </Center>
             )}
+
+            <ExternalLinks
+              conditions={{
+                カタリバ: household.世帯一覧.世帯1.子一覧?.length > 0,
+              }}
+            />
 
             <Center pr={4} pl={4} pb={2}>
               <Text color="blue.900">

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -167,6 +167,14 @@
     "shareLinkButtonText": "結果のリンクをコピー",
     "shareLinkButtonCopiedToClipboard": "クリップボードにコピーしました",
     "consultationDescription": "まずは窓口に相談してみませんか？ きっとあなたの相談に寄り添ってくれるはずです",
+    "externalLinks": {
+      "カタリバ": {
+        "description": "窓口に相談する前に話を整理したい方へ",
+        "buttonText": "NPOカタリバの相談チャットに相談する",
+        "url": "https://www.katariba.or.jp/support/",
+        "color": "#00AB8D"
+      }
+    },
     "helpDeskDescription": {
       "社会福祉協議会": {
         "description1": "まずは近くの社会福祉協議会に相談してみませんか？",


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は フロントエンドの見積もり結果に関連の窓口サイトリンク を追加する
  - そのために NPOカタリバへのリンク を追加した

## 動作確認

- [x] 追加した部分の影響しそうな箇所を目視確認した
  - 子どもがいる場合のみリンクが表示される

<img width="769" height="732" alt="image" src="https://github.com/user-attachments/assets/55003558-9054-4659-acd8-4c0b6972b68b" />

