### PR TITLE
外部リンクの文字がはみ出ないようにする

### DIFF
--- a/dashboard/src/components/result/externalLinks.tsx
+++ b/dashboard/src/components/result/externalLinks.tsx
@@ -20,7 +20,7 @@ export const ExternalLinks = ({
             <Button
               as={RouterLink}
               to={configData.result.externalLinks.カタリバ.url}
-              fontSize={configData.style.subTitleFontSize}
+              fontSize={configData.style.externalLinkFontSize}
               borderRadius="xl"
               height="2em"
               width="100%"

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -177,7 +177,7 @@
     "externalLinks": {
       "カタリバ": {
         "description": "窓口に相談する前に話を整理したい方へ",
-        "buttonText": "NPOカタリバの相談チャットに相談する",
+        "buttonText": "NPOカタリバの相談チャットを利用",
         "url": "https://www.katariba.or.jp/support/",
         "color": "#00AB8D"
       }

--- a/dashboard/src/config/app_config.json
+++ b/dashboard/src/config/app_config.json
@@ -60,6 +60,13 @@
       "lg": "1em",
       "xl": "1em"
     },
+    "externalLinkFontSize": {
+      "base": "1.05em",
+      "sm": "1.3em",
+      "md": "1.5em",
+      "lg": "1.7em",
+      "xl": "1.7em"
+    },
     "selectPrefectureSize": {
       "base": "10em",
       "sm": "10em",


### PR DESCRIPTION
## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は スマートフォンで 見積もり結果の外部リンクの文字が左右にはみ出てしまう問題 を修正する
  - そのために 画面幅ごとのフォントサイズ定義 を変更した

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した

width: 340px
(before)

<img width="336" height="373" alt="image" src="https://github.com/user-attachments/assets/f17ad311-d386-4169-801b-0fc106613140" />

(after)

<img width="334" height="306" alt="image" src="https://github.com/user-attachments/assets/06c4a5f3-5b0b-4716-8241-6b103283b8f3" />

(PC等幅の広い画面では従来通りのフォントサイズ)

<img width="953" height="220" alt="image" src="https://github.com/user-attachments/assets/970fa18f-0c46-43d3-ba49-1a3af1b4f317" />
