### PR TITLE
スマートフォンにおいて「能登半島地震被災者支援制度見積もり」ボタンなどの左右に余白を作成しつつ、PCのデザインを維持する

### DIFF
--- a/dashboard/src/components/top/topPage.tsx
+++ b/dashboard/src/components/top/topPage.tsx
@@ -128,12 +128,12 @@ export function TopPage({
               pr="1em"
               pl="1em"
               height="auto"
-              width={{ base: "80vw", md: "100%" }}
+              width={{ base: '80vw', md: '100%' }}
               minHeight="3.5em"
               bg="orange.400"
               color="white"
               _hover={{ bg: 'orange.500' }}
-              whiteSpace={{ base: "normal", md: "nowrap" }}
+              whiteSpace={{ base: 'normal', md: 'nowrap' }}
             >
               能登半島地震被災者支援制度見積もり
             </Button>
@@ -155,7 +155,7 @@ export function TopPage({
               fontSize={configData.style.subTitleFontSize}
               borderRadius="xl"
               height="auto"
-              width={{ base: "40vw", md: "45%" }}
+              width={{ base: '40vw', md: '45%' }}
               minHeight="3.5em"
               pr="1.2em"
               pl="1.2em"
@@ -163,7 +163,7 @@ export function TopPage({
               color="white"
               _hover={{ bg: 'teal.600' }}
               data-testid="calculate-simple-button"
-              whiteSpace={{ base: "normal", md: "nowrap" }}
+              whiteSpace={{ base: 'normal', md: 'nowrap' }}
             >
               かんたん見積もり
             </Button>
@@ -181,7 +181,7 @@ export function TopPage({
               fontSize={configData.style.subTitleFontSize}
               borderRadius="xl"
               height="auto"
-              width={{ base: "40vw", md: "45%" }}
+              width={{ base: '40vw', md: '45%' }}
               minHeight="3.5em"
               pr="1.2em"
               pl="1.2em"
@@ -189,7 +189,7 @@ export function TopPage({
               color="white"
               _hover={{ bg: 'blue.600' }}
               data-testid="calculate-detail-button"
-              whiteSpace={{ base: "normal", md: "nowrap" }}
+              whiteSpace={{ base: 'normal', md: 'nowrap' }}
             >
               くわしく見積もり
             </Button>

--- a/dashboard/src/components/top/topPage.tsx
+++ b/dashboard/src/components/top/topPage.tsx
@@ -127,11 +127,13 @@ export function TopPage({
               borderRadius="xl"
               pr="1em"
               pl="1em"
-              height="3.5em"
-              width="100%"
+              height="auto"
+              width={{ base: "80vw", md: "100%" }}
+              minHeight="3.5em"
               bg="orange.400"
               color="white"
               _hover={{ bg: 'orange.500' }}
+              whiteSpace={{ base: "normal", md: "nowrap" }}
             >
               能登半島地震被災者支援制度見積もり
             </Button>
@@ -152,14 +154,16 @@ export function TopPage({
               style={{ marginRight: '1%' }}
               fontSize={configData.style.subTitleFontSize}
               borderRadius="xl"
-              height="3.5em"
+              height="auto"
+              width={{ base: "40vw", md: "45%" }}
+              minHeight="3.5em"
               pr="1.2em"
               pl="1.2em"
-              width="45%"
               bg="teal.500"
               color="white"
               _hover={{ bg: 'teal.600' }}
               data-testid="calculate-simple-button"
+              whiteSpace={{ base: "normal", md: "nowrap" }}
             >
               かんたん見積もり
             </Button>
@@ -176,14 +180,16 @@ export function TopPage({
               }}
               fontSize={configData.style.subTitleFontSize}
               borderRadius="xl"
-              height="3.5em"
+              height="auto"
+              width={{ base: "40vw", md: "45%" }}
+              minHeight="3.5em"
               pr="1.2em"
               pl="1.2em"
-              width="45%"
               bg="blue.500"
               color="white"
               _hover={{ bg: 'blue.600' }}
               data-testid="calculate-detail-button"
+              whiteSpace={{ base: "normal", md: "nowrap" }}
             >
               くわしく見積もり
             </Button>


### PR DESCRIPTION
## 対応するIssue

#457

## Pull request前の確認
- [x] フォークしたリポジトリの**develop**ブランチ（あるいはそこから新たに切ったブランチ）にプッシュを行った。（mainブランチに直接プッシュしていない。）
- [x] プルリクエストでマージを要求するブランチをmainブランチから**develop**ブランチに変更した。

## 概要

- この Pull request は スマートフォンにおいて「能登半島地震被災者支援制度見積もり」ボタンなどの余白を改善する
  - そのために 「能登半島地震被災者支援制度見積もり」ボタン、「かんたん見積もり」ボタン、「くわしく見積もりボタン」にattr
    - 最小のheight
    - widthの分岐し、スマートフォンの場合、%をやめ、`vw`単位でサイズを指定する
    - ボタン内の文字改行の許可
  - を追加した
  - PC版のデザインを維持する

## 動作確認

- [x] 変更した部分の影響しそうな箇所を目視確認した
## スクリーンショット

## PC(全画面)
<img width="2878" height="1704" alt="image" src="https://github.com/user-attachments/assets/86a1bc15-4163-4c89-acc9-d05507645a06" />

## スマートフォン
<img width="2878" height="1704" alt="image" src="https://github.com/user-attachments/assets/704c50ac-61d4-4636-88b5-0a8b63627264" />

## 相談したいこと
* 余白サイズがこれで適切かどうか、確認したい
* [issueにも書かれているが](https://github.com/project-inclusive/OpenFisca-Japan/issues/457#:~:text=%E3%82%88%E3%81%86%E3%81%AB%E3%81%97%E3%81%A6%E3%80%81-,%E3%83%9C%E3%82%BF%E3%83%B33%E3%81%A4%E7%B8%A6%E4%B8%A6%E3%81%B3%E3%81%AB%E3%81%97%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86%EF%BC%9F,-%E3%81%82%E3%82%8F%E3%81%9B%E3%81%A6%E3%80%81%E7%81%BD%E5%AE%B3%E6%94%AF%E6%8F%B4)、スマートフォンの場合、ボタンを縦に配置するかどうかお聞きしたい
* 調整のため様々な細かいattrを各ボタンに追加しているため、コードの保守性が心配

